### PR TITLE
Fix: treat MaxInt64 vesting timestamps as perpetual (no end time)

### DIFF
--- a/pkg/indexer/decode/handle/test/vesting_test.go
+++ b/pkg/indexer/decode/handle/test/vesting_test.go
@@ -4,10 +4,11 @@
 package handle_test
 
 import (
+	"math"
 	"testing"
 	"time"
 
-	"cosmossdk.io/math"
+	cosmosmath "cosmossdk.io/math"
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	storageTypes "github.com/celenium-io/celestia-indexer/internal/storage/types"
 	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
@@ -21,7 +22,7 @@ import (
 // MsgCreateVestingAccount
 
 func createMsgCreateVestingAccount() types.Msg {
-	amount, _ := math.NewIntFromString("1000")
+	amount, _ := cosmosmath.NewIntFromString("1000")
 	m := cosmosVestingTypes.MsgCreateVestingAccount{
 		FromAddress: "celestia1j33593mn9urzydakw06jdun8f37shlucmhr8p6",
 		ToAddress:   "celestia1vsvx8n7f8dh5udesqqhgrjutyun7zqrgehdq2l",
@@ -146,7 +147,7 @@ func createMsgCreatePeriodicVestingAccount() types.Msg {
 		VestingPeriods: []cosmosVestingTypes.Period{
 			{
 				Length: 1000,
-				Amount: types.NewCoins(types.NewCoin("utia", math.OneInt())),
+				Amount: types.NewCoins(types.NewCoin("utia", cosmosmath.OneInt())),
 			},
 		},
 	}
@@ -205,4 +206,109 @@ func TestDecodeMsg_SuccessOnMsgCreatePeriodicVestingAccount(t *testing.T) {
 	require.Equal(t, msgExpected, dm.Msg)
 	require.Len(t, decodeCtx.VestingAccounts, 1)
 	require.Equal(t, vestingAccount, decodeCtx.VestingAccounts[0])
+}
+
+func TestDecodeMsg_SuccessOnMsgCreateVestingAccount_MaxInt64EndTime(t *testing.T) {
+	amount, _ := cosmosmath.NewIntFromString("1000")
+	m := &cosmosVestingTypes.MsgCreateVestingAccount{
+		FromAddress: "celestia1j33593mn9urzydakw06jdun8f37shlucmhr8p6",
+		ToAddress:   "celestia1vsvx8n7f8dh5udesqqhgrjutyun7zqrgehdq2l",
+		Amount: types.Coins{
+			{Denom: "utia", Amount: amount},
+		},
+		EndTime: math.MaxInt64,
+		Delayed: false,
+	}
+
+	block, now := testsuite.EmptyBlock()
+	position := 0
+	txId := uint64(1)
+
+	decodeCtx := context.NewContext()
+	decodeCtx.Block = &storage.Block{
+		Height: block.Height,
+		Time:   block.Block.Time,
+	}
+
+	dm, err := decode.Message(decodeCtx, m, position, storageTypes.StatusSuccess, txId)
+
+	require.NoError(t, err)
+	require.Equal(t, int64(0), dm.BlobsSize)
+	require.Len(t, decodeCtx.VestingAccounts, 1)
+
+	va := decodeCtx.VestingAccounts[0]
+	require.Nil(t, va.EndTime, "EndTime must be nil when MaxInt64 is passed")
+	require.Nil(t, va.StartTime)
+	require.Equal(t, storageTypes.VestingTypeContinuous, va.Type)
+	require.Equal(t, storageTypes.MsgCreateVestingAccount, dm.Msg.Type)
+	require.Equal(t, now, dm.Msg.Time)
+}
+
+func TestDecodeMsg_SuccessOnMsgCreateVestingAccount_MaxInt64StartTime(t *testing.T) {
+	amount, _ := cosmosmath.NewIntFromString("500")
+	m := &cosmosVestingTypes.MsgCreateVestingAccount{
+		FromAddress: "celestia1j33593mn9urzydakw06jdun8f37shlucmhr8p6",
+		ToAddress:   "celestia1vsvx8n7f8dh5udesqqhgrjutyun7zqrgehdq2l",
+		Amount: types.Coins{
+			{Denom: "utia", Amount: amount},
+		},
+		StartTime: math.MaxInt64,
+		EndTime:   1710357710,
+		Delayed:   true,
+	}
+
+	block, _ := testsuite.EmptyBlock()
+	position := 0
+	txId := uint64(1)
+
+	decodeCtx := context.NewContext()
+	decodeCtx.Block = &storage.Block{
+		Height: block.Height,
+		Time:   block.Block.Time,
+	}
+
+	_, err := decode.Message(decodeCtx, m, position, storageTypes.StatusSuccess, txId)
+
+	require.NoError(t, err)
+	require.Len(t, decodeCtx.VestingAccounts, 1)
+
+	va := decodeCtx.VestingAccounts[0]
+	require.Nil(t, va.StartTime, "StartTime must be nil when MaxInt64 is passed")
+	require.NotNil(t, va.EndTime)
+	require.Equal(t, storageTypes.VestingTypeDelayed, va.Type)
+}
+
+func TestDecodeMsg_SuccessOnMsgCreatePeriodicVestingAccount_MaxInt64StartTime(t *testing.T) {
+	m := &cosmosVestingTypes.MsgCreatePeriodicVestingAccount{
+		FromAddress: "celestia1j33593mn9urzydakw06jdun8f37shlucmhr8p6",
+		ToAddress:   "celestia1vsvx8n7f8dh5udesqqhgrjutyun7zqrgehdq2l",
+		StartTime:   math.MaxInt64,
+		VestingPeriods: []cosmosVestingTypes.Period{
+			{
+				Length: 1000,
+				Amount: types.NewCoins(types.NewCoin("utia", cosmosmath.OneInt())),
+			},
+		},
+	}
+
+	block, _ := testsuite.EmptyBlock()
+	position := 0
+	txId := uint64(1)
+
+	decodeCtx := context.NewContext()
+	decodeCtx.Block = &storage.Block{
+		Height: block.Height,
+		Time:   block.Block.Time,
+	}
+
+	_, err := decode.Message(decodeCtx, m, position, storageTypes.StatusSuccess, txId)
+
+	require.NoError(t, err)
+	require.Len(t, decodeCtx.VestingAccounts, 1)
+
+	va := decodeCtx.VestingAccounts[0]
+	require.Nil(t, va.StartTime, "StartTime must be nil when MaxInt64 is passed")
+	require.Equal(t, storageTypes.VestingTypePeriodic, va.Type)
+	// period time falls back to block time when StartTime is ignored
+	require.Equal(t, block.Block.Time.Add(1000*time.Second), va.VestingPeriods[0].Time)
 }

--- a/pkg/indexer/decode/handle/vesting.go
+++ b/pkg/indexer/decode/handle/vesting.go
@@ -4,6 +4,7 @@
 package handle
 
 import (
+	"math"
 	"time"
 
 	"github.com/celenium-io/celestia-indexer/internal/currency"
@@ -37,11 +38,11 @@ func MsgCreateVestingAccount(ctx *context.Context, status storageTypes.Status, t
 	amount := storageTypes.NumericFromBigInt(m.Amount.AmountOf(currency.Utia).BigInt(), 0)
 	v.Amount = v.Amount.Add(amount)
 
-	if m.EndTime > 0 {
+	if m.EndTime > 0 && m.EndTime != math.MaxInt64 {
 		t := time.Unix(m.EndTime, 0).UTC()
 		v.EndTime = &t
 	}
-	if m.StartTime > 0 {
+	if m.StartTime > 0 && m.StartTime != math.MaxInt64 {
 		t := time.Unix(m.StartTime, 0).UTC()
 		v.StartTime = &t
 	}
@@ -113,7 +114,7 @@ func MsgCreatePeriodicVestingAccount(ctx *context.Context, status storageTypes.S
 	}
 
 	periodTime := v.Time
-	if m.StartTime > 0 {
+	if m.StartTime > 0 && m.StartTime != math.MaxInt64 {
 		t := time.Unix(m.StartTime, 0).UTC()
 		v.StartTime = &t
 		periodTime = t


### PR DESCRIPTION
## Problem

Indexing failed with the following error when processing `MsgCreateVestingAccount` transactions:

```
transaction error: saving vesting accounts:
ERROR: date/time field value out of range: "292277026596-12-04 15:30:07+00:00" (SQLSTATE 22008)
```

The root cause: some vesting messages on-chain carry `EndTime = 9223372036854775807` (`math.MaxInt64`). The Cosmos SDK uses this value as a sentinel meaning "no expiry" / "perpetual vesting". When passed to `time.Unix(math.MaxInt64, 0)`, it produces the year ~292 billion — well beyond PostgreSQL's timestamp range (max ~year 294276 AD), causing the DB insert to fail.

## Fix

Added a guard in `MsgCreateVestingAccount` and `MsgCreatePeriodicVestingAccount` handlers: if `StartTime` or `EndTime` equals `math.MaxInt64`, the field is left as `nil` in the stored `VestingAccount`. This correctly represents the "no expiry" semantics in the database.

```go
// before
if m.EndTime > 0 {

// after
if m.EndTime > 0 && m.EndTime != math.MaxInt64 {
```

## Tests

Added three test cases covering the edge cases:
- `MsgCreateVestingAccount` with `EndTime = math.MaxInt64` → `EndTime` stored as `nil`
- `MsgCreateVestingAccount` with `StartTime = math.MaxInt64` and a valid `EndTime` → `StartTime` is `nil`, `EndTime` is preserved
- `MsgCreatePeriodicVestingAccount` with `StartTime = math.MaxInt64` → `StartTime` is `nil`, vesting period times fall back to block time as the base