### PR TITLE
Replace deprecated marvinpinto/action-automatic-releases with softprops/action-gh-release

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,32 +11,23 @@ jobs:
   pre-release:
     name: Pre-release
     runs-on: ubuntu-latest
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Set up environment
-        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
-
       - name: Publish GitHub release
-        uses: "marvinpinto/action-automatic-releases@v1.2.1"
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          generate_release_notes: true
           prerelease: true
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   sentry:
     name: Sentry release
     runs-on: ubuntu-latest
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-
-      - name: Set up environment
-        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
 
       - name: Create Sentry release
         uses: getsentry/action-release@v1
@@ -47,5 +38,5 @@ jobs:
           SENTRY_URL: "${{ secrets.SENTRY_URL }}"
         with:
           environment: production
-          version: "${{ env.RELEASE_VERSION }}"
+          version: "${{ github.ref_name }}"
           ignore_empty: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,32 +11,22 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Set up environment
-        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
-
       - name: Publish GitHub release
-        uses: "marvinpinto/action-automatic-releases@v1.2.1"
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          prerelease: false
+          generate_release_notes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   sentry:
     name: Sentry release
     runs-on: ubuntu-latest
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-
-      - name: Set up environment
-        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
 
       - name: Create Sentry release
         uses: getsentry/action-release@v1
@@ -47,6 +37,5 @@ jobs:
           SENTRY_URL: "${{ secrets.SENTRY_URL }}"
         with:
           environment: production
-          version: "${{ env.RELEASE_VERSION }}"
+          version: "${{ github.ref_name }}"
           ignore_empty: true
-        


### PR DESCRIPTION
`marvinpinto/action-automatic-releases` has not been maintained since 2021. This replaces it with `softprops/action-gh-release@v2` in both `release.yml` and `prerelease.yml`.

Changes:
- Switch to `softprops/action-gh-release@v2` with `generate_release_notes: true` — automatically generates changelog from commits and merged PRs
- Remove `ACTIONS_ALLOW_UNSECURE_COMMANDS: true` — deprecated flag no longer needed
- Remove `echo ::set-env` step — deprecated workflow command; replace with `${{ github.ref_name }}` where the version was used (Sentry job)