### PR TITLE
Fix: apply v7 upgrade when jumping directly to v8

### DIFF
--- a/pkg/indexer/storage/upgrades.go
+++ b/pkg/indexer/storage/upgrades.go
@@ -18,7 +18,7 @@ func (module *Module) upgrade(ctx context.Context, decodeContext *decodeContext.
 	}
 
 	switch targetVersion {
-	case 1, 2, 3, 4, 5, 8, 9:
+	case 1, 2, 3, 4, 5, 9:
 		// No upgrade logic needed for these versions
 	case 6:
 		// CIP-037 Reduce the validator unbonding period from 21 days to 14 days and 1 hour to improve capital efficiency while maintaining network security (https://cips.celestia.org/cip-037.html)
@@ -30,6 +30,12 @@ func (module *Module) upgrade(ctx context.Context, decodeContext *decodeContext.
 	case 7:
 		if err := module.upgradeV7(ctx, decodeContext, targetVersion); err != nil {
 			return errors.Wrap(err, "failed to upgrade to version 7")
+		}
+	case 8:
+		if currentVersion < 7 {
+			if err := module.upgradeV7(ctx, decodeContext, 7); err != nil {
+				return errors.Wrap(err, "failed to upgrade to version 7")
+			}
 		}
 	default:
 		return errors.Errorf("unsupported upgrade version: %d", targetVersion)

--- a/pkg/indexer/storage/upgrades_test.go
+++ b/pkg/indexer/storage/upgrades_test.go
@@ -17,6 +17,19 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+var testValidators = []*storage.Validator{
+	{
+		Id:      1,
+		Rate:    storageTypes.MustNumericFromString("0.150000000000000000"),
+		MaxRate: storageTypes.MustNumericFromString("0.500000000000000000"),
+	},
+	{
+		Id:      2,
+		Rate:    storageTypes.MustNumericFromString("0.250000000000000000"),
+		MaxRate: storageTypes.MustNumericFromString("0.700000000000000000"),
+	},
+}
+
 func TestUpgradeV7(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -24,18 +37,7 @@ func TestUpgradeV7(t *testing.T) {
 	validators := mock.NewMockIValidator(ctrl)
 	validators.EXPECT().
 		List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		Return([]*storage.Validator{
-			{
-				Id:      1,
-				Rate:    storageTypes.MustNumericFromString("0.150000000000000000"),
-				MaxRate: storageTypes.MustNumericFromString("0.500000000000000000"),
-			},
-			{
-				Id:      2,
-				Rate:    storageTypes.MustNumericFromString("0.250000000000000000"),
-				MaxRate: storageTypes.MustNumericFromString("0.700000000000000000"),
-			},
-		}, nil).
+		Return(testValidators, nil).
 		Times(1)
 
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -66,5 +68,103 @@ func TestUpgradeV7(t *testing.T) {
 		}
 		return nil, true
 	})
+	require.NoError(t, err)
+}
+
+// TestUpgrade_V8WithoutPriorV7 checks that upgrading to v8 when v7 was never applied
+// also runs the v7 upgrade logic (validator commission adjustments + constants).
+func TestUpgrade_V8WithoutPriorV7(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	validators := mock.NewMockIValidator(ctrl)
+	validators.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(testValidators, nil).
+		Times(1)
+
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
+
+	module := NewModule(nil, nil, validators, nil, indexerCfg.Indexer{Name: testIndexerName})
+	dCtx := decodeContext.NewContext()
+
+	err := module.upgrade(ctx, dCtx, 6, 8)
+	require.NoError(t, err)
+
+	minCommissionRate := storageTypes.MustNumericFromString("0.200000000000000000")
+	maxCommissionRate := storageTypes.MustNumericFromString("0.600000000000000000")
+
+	err = dCtx.Validators.Range(func(_ string, v *storage.Validator) (error, bool) {
+		require.True(t, v.Rate.GreaterThanOrEqual(minCommissionRate))
+		require.True(t, v.MaxRate.LessThanOrEqual(maxCommissionRate))
+		return nil, false
+	})
+	require.NoError(t, err)
+
+	var foundMin, foundMax bool
+	err = dCtx.Constants.Range(func(_ string, c *storage.Constant) (error, bool) {
+		if c.Name == "min_commission_rate" {
+			require.Equal(t, "0.200000000000000000", c.Value)
+			foundMin = true
+		}
+		if c.Name == "max_commission_rate" {
+			require.Equal(t, "0.600000000000000000", c.Value)
+			foundMax = true
+		}
+		return nil, false
+	})
+	require.NoError(t, err)
+	require.True(t, foundMin, "min_commission_rate constant must be set by v7 upgrade")
+	require.True(t, foundMax, "max_commission_rate constant must be set by v7 upgrade")
+}
+
+// TestUpgrade_V8WithPriorV7 checks that when v7 was already applied (currentVersion=7),
+// upgrading to v8 does NOT re-run the v7 logic.
+func TestUpgrade_V8WithPriorV7(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	validators := mock.NewMockIValidator(ctrl)
+	// List must never be called — v7 logic must be skipped entirely.
+	validators.EXPECT().
+		List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Times(0)
+
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
+
+	module := NewModule(nil, nil, validators, nil, indexerCfg.Indexer{Name: testIndexerName})
+	dCtx := decodeContext.NewContext()
+
+	err := module.upgrade(ctx, dCtx, 7, 8)
+	require.NoError(t, err)
+
+	count := 0
+	_ = dCtx.Validators.Range(func(_ string, _ *storage.Validator) (error, bool) {
+		count++
+		return nil, true
+	})
+	require.Zero(t, count, "no validators should be modified when v7 was already applied")
+}
+
+// TestUpgrade_NoOpWhenCurrentGTE checks the early-return guard.
+func TestUpgrade_NoOpWhenCurrentGTE(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	validators := mock.NewMockIValidator(ctrl)
+	validators.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ctxCancel()
+
+	module := NewModule(nil, nil, validators, nil, indexerCfg.Indexer{Name: testIndexerName})
+	dCtx := decodeContext.NewContext()
+
+	err := module.upgrade(ctx, dCtx, 8, 8)
+	require.NoError(t, err)
+
+	err = module.upgrade(ctx, dCtx, 9, 8)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Previously, version 8 was listed alongside no-op versions (1–5, 9), meaning the v7 upgrade logic (CIP-044 validator commission adjustments) was silently skipped if a node went directly from v6 → v8 without passing through v7.

**What changed:**

- Removed `8` from the no-op `case` list in `upgrade()`
- Added a dedicated `case 8` that checks whether v7 was already applied (`currentVersion < 7`) and, if not, runs `upgradeV7` first — updating `min_commission_rate` / `max_commission_rate` constants and clamping all validator commissions to the CIP-044 bounds