### PR TITLE
Fix: trust-aware client IP extraction

### DIFF
--- a/cmd/api/config.go
+++ b/cmd/api/config.go
@@ -31,4 +31,5 @@ type ApiConfig struct {
 	DefaultCacheTTL       int     `validate:"omitempty,min=1"        yaml:"default_cache_ttl"`
 	HyperlaneNodeUrl      string  `validate:"omitempty,url"          yaml:"hyperlane_node"`
 	WebscoketClientsPerIp int     `validate:"omitempty,min=1"        yaml:"websocket_clients_per_ip"`
+	TrustedProxies        string  `validate:"omitempty"              yaml:"trusted_proxies"`
 }

--- a/cmd/api/init.go
+++ b/cmd/api/init.go
@@ -21,6 +21,7 @@ import (
 	"github.com/celenium-io/celestia-indexer/cmd/api/ibc_relayer"
 	"github.com/celenium-io/celestia-indexer/internal/blob"
 	"github.com/celenium-io/celestia-indexer/internal/profiler"
+	"github.com/celenium-io/celestia-indexer/internal/realip"
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/postgres"
 	"github.com/celenium-io/celestia-indexer/pkg/node"
@@ -167,6 +168,12 @@ func observableCacheSkipper(c echo.Context) bool {
 func initEcho(cfg ApiConfig, env string) *echo.Echo {
 	e := echo.New()
 	e.Validator = handler.NewCelestiaApiValidator()
+
+	extractor, err := realip.Extractor(cfg.TrustedProxies)
+	if err != nil {
+		log.Panic().Err(err).Msg("parsing trusted proxies")
+	}
+	e.IPExtractor = extractor
 
 	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
 		LogURI:       true,

--- a/cmd/private_api/init.go
+++ b/cmd/private_api/init.go
@@ -88,6 +88,9 @@ func initLogger(level, loggerType string) error {
 func initEcho(cfg ApiConfig) *echo.Echo {
 	e := echo.New()
 	e.Validator = handler.NewCelestiaApiValidator()
+
+	e.IPExtractor = echo.ExtractIPDirect()
+
 	timeout := 30 * time.Second
 
 	e.Use(middleware.TimeoutWithConfig(middleware.TimeoutConfig{

--- a/configs/dipdup.yml
+++ b/configs/dipdup.yml
@@ -67,6 +67,7 @@ api:
   default_cache_ttl: ${CACHE_DEFAULT_TTL:-5}
   hyperlane_node: ${HYPERLANE_NODE_URL}
   websocket_clients_per_ip: ${API_WEBSOCKET_CLIENTS_PER_IP:-10}
+  trusted_proxies: ${API_TRUSTED_PROXIES}
   
 private_api:
   bind: ${PRIVATE_API_HOST:-0.0.0.0}:${PRIVATE_API_PORT:-9877}

--- a/internal/realip/extractor.go
+++ b/internal/realip/extractor.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2025 Bb Strategy Pte. Ltd. <celenium@baking-bad.org>
+// SPDX-License-Identifier: MIT
+
+package realip
+
+import (
+	"net"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+)
+
+// Extractor returns an echo.IPExtractor built from a comma-separated list of
+// trusted proxy addresses (single IPs or CIDR ranges). X-Forwarded-For is
+// honored only for connections coming from these addresses. When the list is
+// empty, the remote address of the connection is always used and forwarding
+// headers are ignored.
+func Extractor(trustedProxies string) (echo.IPExtractor, error) {
+	options := []echo.TrustOption{
+		echo.TrustLoopback(false),
+		echo.TrustLinkLocal(false),
+		echo.TrustPrivateNet(false),
+	}
+
+	var trusted int
+	for _, proxy := range strings.Split(trustedProxies, ",") {
+		proxy = strings.TrimSpace(proxy)
+		if proxy == "" {
+			continue
+		}
+		if !strings.Contains(proxy, "/") {
+			ip := net.ParseIP(proxy)
+			if ip == nil {
+				return nil, errors.Errorf("invalid trusted proxy address: %s", proxy)
+			}
+			bits := 32
+			if ip.To4() == nil {
+				bits = 128
+			}
+			options = append(options, echo.TrustIPRange(&net.IPNet{
+				IP:   ip,
+				Mask: net.CIDRMask(bits, bits),
+			}))
+			trusted++
+			continue
+		}
+		_, ipNet, err := net.ParseCIDR(proxy)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid trusted proxy range: %s", proxy)
+		}
+		options = append(options, echo.TrustIPRange(ipNet))
+		trusted++
+	}
+
+	if trusted == 0 {
+		return echo.ExtractIPDirect(), nil
+	}
+	return echo.ExtractIPFromXFFHeader(options...), nil
+}

--- a/internal/realip/extractor_test.go
+++ b/internal/realip/extractor_test.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2025 Bb Strategy Pte. Ltd. <celenium@baking-bad.org>
+// SPDX-License-Identifier: MIT
+
+package realip
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newRequest(remoteAddr, xff string) *http.Request {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req.RemoteAddr = remoteAddr
+	if xff != "" {
+		req.Header.Set("X-Forwarded-For", xff)
+	}
+	return req
+}
+
+func TestExtractor(t *testing.T) {
+	tests := []struct {
+		name           string
+		trustedProxies string
+		remoteAddr     string
+		xff            string
+		want           string
+	}{
+		{
+			name:           "empty config ignores forwarding headers",
+			trustedProxies: "",
+			remoteAddr:     "203.0.113.10:51000",
+			xff:            "1.2.3.4",
+			want:           "203.0.113.10",
+		},
+		{
+			name:           "direct client cannot spoof via header",
+			trustedProxies: "198.51.100.7",
+			remoteAddr:     "203.0.113.10:51000",
+			xff:            "1.2.3.4",
+			want:           "203.0.113.10",
+		},
+		{
+			name:           "trusted proxy header is honored",
+			trustedProxies: "198.51.100.7",
+			remoteAddr:     "198.51.100.7:43000",
+			xff:            "203.0.113.10",
+			want:           "203.0.113.10",
+		},
+		{
+			name:           "client-supplied entry behind trusted proxy is skipped",
+			trustedProxies: "198.51.100.7",
+			remoteAddr:     "198.51.100.7:43000",
+			xff:            "1.2.3.4, 203.0.113.10",
+			want:           "203.0.113.10",
+		},
+		{
+			name:           "cidr range",
+			trustedProxies: "198.51.100.0/24",
+			remoteAddr:     "198.51.100.42:43000",
+			xff:            "203.0.113.10",
+			want:           "203.0.113.10",
+		},
+		{
+			name:           "multiple proxies comma separated",
+			trustedProxies: "192.0.2.1, 198.51.100.7",
+			remoteAddr:     "192.0.2.1:43000",
+			xff:            "203.0.113.10",
+			want:           "203.0.113.10",
+		},
+		{
+			name:           "private remote addr is not trusted by default",
+			trustedProxies: "198.51.100.7",
+			remoteAddr:     "10.0.0.2:43000",
+			xff:            "1.2.3.4",
+			want:           "10.0.0.2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extractor, err := Extractor(tt.trustedProxies)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, extractor(newRequest(tt.remoteAddr, tt.xff)))
+		})
+	}
+}
+
+func TestExtractorInvalid(t *testing.T) {
+	for _, value := range []string{"not-an-ip", "10.0.0.0/99", "1.2.3.4;5.6.7.8"} {
+		_, err := Extractor(value)
+		require.Error(t, err, value)
+	}
+}


### PR DESCRIPTION
### Problem

Echo's default `RealIP()` resolution trusts `X-Forwarded-For` and `X-Real-IP` headers from any client. Since these headers are attacker-controlled, anyone could spoof their IP address, which affects everything built on top of `RealIP()`:

- **rate limiter** — a fresh identity per request bypasses the limit entirely and bloats the in-memory visitor store;
- **websocket per-IP connection limit** — the `websocket_clients_per_ip` cap can be bypassed by rotating the header value;
- **request logs and Sentry** — forged addresses poison audit trails and incident investigation.

### Changes

**New `internal/realip` package**

`realip.Extractor(trustedProxies string)` builds an `echo.IPExtractor` from a comma-separated list of trusted proxy addresses (single IPs or CIDR ranges, IPv4/IPv6):

- empty list → `ExtractIPDirect()`: the TCP connection address is always used, forwarding headers are ignored;
- non-empty list → `ExtractIPFromXFFHeader` honoring `X-Forwarded-For` **only** for connections originating from the listed addresses. Echo's default trust of loopback, link-local and private ranges is explicitly disabled, so co-located containers cannot spoof the header either;
- invalid entries fail fast at startup instead of silently degrading to an unsafe mode.

**Public API**

New `trusted_proxies` setting (`API_TRUSTED_PROXIES` env var, empty by default). Deployments behind a reverse proxy should set it to the proxy address; everything else keeps the safe direct-extraction behavior.

**Private API**

Hardcoded `echo.ExtractIPDirect()` — the private API is not expected to sit behind a proxy, so forwarding headers are never trusted and no configuration is exposed.

### Tests

Unit tests cover: direct clients cannot spoof via headers, trusted proxies can forward the real client IP, client-supplied entries behind a trusted proxy are skipped, private-range remotes are not trusted by default, CIDR and multi-entry lists, and rejection of malformed values.