### PR TITLE
Fix: remove permissive CORS from private API

### DIFF
--- a/cmd/private_api/init.go
+++ b/cmd/private_api/init.go
@@ -139,7 +139,6 @@ func initEcho(cfg ApiConfig) *echo.Echo {
 		},
 	}))
 	e.Use(middleware.BodyLimit("2M"))
-	e.Use(middleware.CORS())
 	e.Use(middleware.Recover())
 	e.Use(middleware.Secure())
 	e.Pre(middleware.RemoveTrailingSlash())


### PR DESCRIPTION
### Problem

The private API registered `middleware.CORS()` with default settings, which responds with `Access-Control-Allow-Origin: *` and allows `PUT`/`PATCH`/`DELETE` plus any requested headers on preflight. This granted every website on the internet permission to interact with the admin API from a visitor's browser and read the responses.

Authentication is key-based (`Authorization` header), so there is no direct credential theft today — browsers don't attach this header automatically. But the wildcard policy is a foot-gun:

- any future endpoint added without `keyMiddleware` becomes readable cross-origin from the browser of anyone with network access to the service (including operators inside the perimeter);
- if cookie/session auth is ever introduced for an admin UI, the wildcard immediately enables classic cross-origin credential abuse.

### Change

Drop the CORS middleware entirely. The private API is consumed by non-browser clients only, which never evaluate CORS headers — so the middleware provided no functionality to legitimate clients while handing out permissions to browsers. Without it, browsers fall back to the default Same-Origin Policy and cross-origin pages cannot read responses.

If a browser-based admin UI appears later, CORS should be re-added with an explicit `AllowOrigins` allowlist instead of the wildcard.