### PR TITLE
Fix: type-safe CSV export query to prevent SQL injection

### DIFF
--- a/internal/storage/generic.go
+++ b/internal/storage/generic.go
@@ -13,6 +13,7 @@ import (
 	celestials "github.com/celenium-io/celestial-module/pkg/storage"
 	sdk "github.com/dipdup-net/indexer-sdk/pkg/storage"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/uptrace/bun"
 )
 
 var Models = []any{
@@ -231,5 +232,5 @@ type ISearch interface {
 
 //go:generate mockgen -source=$GOFILE -destination=mock/$GOFILE -package=mock -typed
 type Export interface {
-	ToCsv(ctx context.Context, writer io.Writer, query string) error
+	ToCsv(ctx context.Context, writer io.Writer, query *bun.SelectQuery) error
 }

--- a/internal/storage/mock/generic.go
+++ b/internal/storage/mock/generic.go
@@ -5425,7 +5425,7 @@ func (m *MockExport) EXPECT() *MockExportMockRecorder {
 }
 
 // ToCsv mocks base method.
-func (m *MockExport) ToCsv(ctx context.Context, writer io.Writer, query string) error {
+func (m *MockExport) ToCsv(ctx context.Context, writer io.Writer, query *bun.SelectQuery) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ToCsv", ctx, writer, query)
 	ret0, _ := ret[0].(error)
@@ -5451,13 +5451,13 @@ func (c *MockExportToCsvCall) Return(arg0 error) *MockExportToCsvCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockExportToCsvCall) Do(f func(context.Context, io.Writer, string) error) *MockExportToCsvCall {
+func (c *MockExportToCsvCall) Do(f func(context.Context, io.Writer, *bun.SelectQuery) error) *MockExportToCsvCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockExportToCsvCall) DoAndReturn(f func(context.Context, io.Writer, string) error) *MockExportToCsvCall {
+func (c *MockExportToCsvCall) DoAndReturn(f func(context.Context, io.Writer, *bun.SelectQuery) error) *MockExportToCsvCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/storage/postgres/blob_log.go
+++ b/internal/storage/postgres/blob_log.go
@@ -169,8 +169,7 @@ func (bl *BlobLog) ExportByProviders(ctx context.Context, providers []storage.Ro
 		Join("left join address as signer on signer.id = blob_log.signer_id").
 		Join("left join namespace as ns on ns.id = blob_log.namespace_id").
 		Join("left join tx on tx.id = blob_log.tx_id").
-		Order("blob_log.time desc").
-		String()
+		Order("blob_log.time desc")
 
 	err = bl.export.ToCsv(ctx, stream, query)
 	return

--- a/internal/storage/postgres/export.go
+++ b/internal/storage/postgres/export.go
@@ -21,7 +21,7 @@ func NewExport(db *database.Bun) *Export {
 	return &Export{db}
 }
 
-func (e *Export) ToCsv(ctx context.Context, writer io.Writer, query string) error {
+func (e *Export) ToCsv(ctx context.Context, writer io.Writer, query *bun.SelectQuery) error {
 	pool := e.Pool()
 	if pool == nil {
 		return errors.New("pool is nil")
@@ -32,7 +32,7 @@ func (e *Export) ToCsv(ctx context.Context, writer io.Writer, query string) erro
 	}
 	defer conn.Release()
 
-	rawQuery := fmt.Sprintf("COPY (%s) TO STDOUT WITH CSV HEADER", bun.Safe(query))
+	rawQuery := fmt.Sprintf("COPY (%s) TO STDOUT WITH CSV HEADER", query.String())
 	_, err = conn.Conn().PgConn().CopyTo(ctx, writer, rawQuery)
 	return err
 }

--- a/internal/storage/postgres/export_test.go
+++ b/internal/storage/postgres/export_test.go
@@ -8,14 +8,22 @@ import (
 	"context"
 	"encoding/csv"
 	"time"
+
+	"github.com/celenium-io/celestia-indexer/internal/storage"
 )
 
 func (s *StorageTestSuite) TestExportToCsv() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer ctxCancel()
 
+	query := s.storage.
+		Connection().DB().
+		NewSelect().
+		Model((*storage.Address)(nil)).
+		Order("id")
+
 	var buf bytes.Buffer
-	err := s.storage.export.ToCsv(ctx, &buf, "select * from address")
+	err := s.storage.export.ToCsv(ctx, &buf, query)
 	s.Require().NoError(err)
 
 	reader := csv.NewReader(bytes.NewReader(buf.Bytes()))


### PR DESCRIPTION
### Problem

`Export.ToCsv` accepted the query as a raw `string` and interpolated it directly into a `COPY (...) TO STDOUT` command via `fmt.Sprintf` with `bun.Safe`. Despite the name, `bun.Safe` performs no escaping — it marks a string as trusted raw SQL, the opposite of sanitization.

The single existing caller built its query through the bun query builder with placeholders, so there was no injection today. But the `ToCsv(ctx, writer, query string)` contract was a foot-gun: any future caller passing a `fmt.Sprintf`-built string would introduce SQL injection that review and static analysis could easily miss. The blast radius is significant — `COPY (...) TO STDOUT` can stream arbitrary statements, including dumping sensitive tables, straight into the HTTP response.

### Change

Narrow the `Export.ToCsv` signature from `string` to `*bun.SelectQuery`:

- the sink renders the builder itself via `query.String()`, so callers can no longer pass hand-built SQL — it's a compile error;
- `*bun.SelectQuery` can only ever be a `SELECT`, removing the risk of arbitrary statement execution through the `COPY` wrapper;
- the misleadingly-named `bun.Safe` is gone.

The single caller (`BlobLog.ExportByProviders`) already builds a `*bun.SelectQuery` and now passes it directly instead of calling `.String()`. The mock is regenerated and the integration test now exercises the builder-based path.