### PR TITLE
Refactoring: transactions by address

### DIFF
--- a/cmd/api/handler/address.go
+++ b/cmd/api/handler/address.go
@@ -20,6 +20,7 @@ import (
 
 type AddressHandler struct {
 	address       storage.IAddress
+	blocks        storage.IBlock
 	txs           storage.ITx
 	blobLogs      storage.IBlobLog
 	messages      storage.IMessage
@@ -36,6 +37,7 @@ type AddressHandler struct {
 
 func NewAddressHandler(
 	address storage.IAddress,
+	blocks storage.IBlock,
 	txs storage.ITx,
 	blobLogs storage.IBlobLog,
 	messages storage.IMessage,
@@ -51,6 +53,7 @@ func NewAddressHandler(
 ) *AddressHandler {
 	return &AddressHandler{
 		address:       address,
+		blocks:        blocks,
 		txs:           txs,
 		blobLogs:      blobLogs,
 		messages:      messages,
@@ -187,12 +190,7 @@ func (handler *AddressHandler) Transactions(c echo.Context) error {
 	}
 	req.SetDefault()
 
-	_, hash, err := types.Address(req.Hash).Decode()
-	if err != nil {
-		return badRequestError(c, err)
-	}
-
-	addressId, err := handler.getIdByHash(c.Request().Context(), hash, req.Hash)
+	address, err := handler.address.AddressByString(c.Request().Context(), req.Hash)
 	if err != nil {
 		return handleError(c, err, handler.address)
 	}
@@ -205,6 +203,23 @@ func (handler *AddressHandler) Transactions(c echo.Context) error {
 		Height:       req.Height,
 		MessageTypes: storageTypes.NewMsgTypeBitMask(),
 	}
+
+	if req.Height == nil {
+		fltrs.WindowFrom, err = handler.blocks.Time(c.Request().Context(), address.Height)
+		if err != nil {
+			return handleError(c, err, handler.blocks)
+		}
+		fltrs.WindowTo, err = handler.blocks.Time(c.Request().Context(), address.LastHeight)
+		if err != nil {
+			return handleError(c, err, handler.blocks)
+		}
+	} else {
+		fltrs.WindowFrom, err = handler.blocks.Time(c.Request().Context(), types.Level(*req.Height))
+		if err != nil {
+			return handleError(c, err, handler.blocks)
+		}
+		fltrs.WindowTo = fltrs.WindowFrom
+	}
 	if req.From > 0 {
 		fltrs.TimeFrom = time.Unix(req.From, 0).UTC()
 	}
@@ -215,7 +230,7 @@ func (handler *AddressHandler) Transactions(c echo.Context) error {
 		fltrs.MessageTypes.SetByMsgType(storageTypes.MsgType(req.MsgType[i]))
 	}
 
-	txs, err := handler.txs.ByAddress(c.Request().Context(), addressId, fltrs)
+	txs, err := handler.txs.ByAddress(c.Request().Context(), address.Id, fltrs)
 	if err != nil {
 		return handleError(c, err, handler.address)
 	}

--- a/cmd/api/handler/address_test.go
+++ b/cmd/api/handler/address_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/celenium-io/celestia-indexer/internal/storage/mock"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
 	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
+	pkgTypes "github.com/celenium-io/celestia-indexer/pkg/types"
 	celestials "github.com/celenium-io/celestial-module/pkg/storage"
 	celestialMock "github.com/celenium-io/celestial-module/pkg/storage/mock"
 	"github.com/labstack/echo/v4"
@@ -44,6 +45,7 @@ var (
 type AddressTestSuite struct {
 	suite.Suite
 	address       *mock.MockIAddress
+	blocks        *mock.MockIBlock
 	txs           *mock.MockITx
 	blobLogs      *mock.MockIBlobLog
 	messages      *mock.MockIMessage
@@ -66,6 +68,7 @@ func (s *AddressTestSuite) SetupSuite() {
 	s.echo.Validator = NewCelestiaApiValidator()
 	s.ctrl = gomock.NewController(s.T())
 	s.address = mock.NewMockIAddress(s.ctrl)
+	s.blocks = mock.NewMockIBlock(s.ctrl)
 	s.txs = mock.NewMockITx(s.ctrl)
 	s.blobLogs = mock.NewMockIBlobLog(s.ctrl)
 	s.messages = mock.NewMockIMessage(s.ctrl)
@@ -77,7 +80,8 @@ func (s *AddressTestSuite) SetupSuite() {
 	s.celestials = celestialMock.NewMockICelestial(s.ctrl)
 	s.votes = mock.NewMockIVote(s.ctrl)
 	s.state = mock.NewMockIState(s.ctrl)
-	s.handler = NewAddressHandler(s.address, s.txs, s.blobLogs, s.messages, s.delegations, s.undelegations, s.redelegations, s.vestings, s.grants, s.celestials, s.votes, s.state, testIndexerName)
+	s.blocks = mock.NewMockIBlock(s.ctrl)
+	s.handler = NewAddressHandler(s.address, s.blocks, s.txs, s.blobLogs, s.messages, s.delegations, s.undelegations, s.redelegations, s.vestings, s.grants, s.celestials, s.votes, s.state, testIndexerName)
 }
 
 // TearDownSuite -
@@ -231,8 +235,19 @@ func (s *AddressTestSuite) TestTransactions() {
 	c.SetParamValues(testAddress)
 
 	s.address.EXPECT().
-		IdByHash(gomock.Any(), testHashAddress).
-		Return([]uint64{1}, nil).
+		AddressByString(gomock.Any(), testAddress).
+		Return(storage.Address{
+			Id:         1,
+			Hash:       testHashAddress,
+			Address:    testAddress,
+			Height:     0,
+			LastHeight: 101,
+		}, nil).
+		Times(1)
+
+	s.blocks.EXPECT().
+		Time(gomock.Any(), pkgTypes.Level(1000)).
+		Return(testTime, nil).
 		Times(1)
 
 	s.txs.EXPECT().

--- a/cmd/api/init.go
+++ b/cmd/api/init.go
@@ -327,7 +327,7 @@ func initHandlers(ctx context.Context, e *echo.Echo, cfg Config, db postgres.Sto
 	searchHandler := handler.NewSearchHandler(db.Search, db.Address, db.Blocks, db.Tx, db.Namespace, db.Validator, db.Rollup, db.Celestials)
 	v1.GET("/search", searchHandler.Search)
 
-	addressHandlers := handler.NewAddressHandler(db.Address, db.Tx, db.BlobLogs, db.Message, db.Delegation, db.Undelegation, db.Redelegation, db.VestingAccounts, db.Grants, db.Celestials, db.Votes, db.State, cfg.Indexer.Name)
+	addressHandlers := handler.NewAddressHandler(db.Address, db.Blocks, db.Tx, db.BlobLogs, db.Message, db.Delegation, db.Undelegation, db.Redelegation, db.VestingAccounts, db.Grants, db.Celestials, db.Votes, db.State, cfg.Indexer.Name)
 	addressesGroup := v1.Group("/address")
 	{
 		addressesGroup.GET("", addressHandlers.List)

--- a/internal/storage/address.go
+++ b/internal/storage/address.go
@@ -30,6 +30,7 @@ type IAddress interface {
 	IdByHash(ctx context.Context, hash ...[]byte) ([]uint64, error)
 	IdByAddress(ctx context.Context, address string, ids ...uint64) (uint64, error)
 	Balances(ctx context.Context, addressId uint64, limit, offset int) ([]Balance, error)
+	AddressByString(ctx context.Context, readableHash string) (Address, error)
 }
 
 // Address -

--- a/internal/storage/mock/address.go
+++ b/internal/storage/mock/address.go
@@ -45,6 +45,45 @@ func (m *MockIAddress) EXPECT() *MockIAddressMockRecorder {
 	return m.recorder
 }
 
+// AddressByString mocks base method.
+func (m *MockIAddress) AddressByString(ctx context.Context, readableHash string) (storage.Address, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddressByString", ctx, readableHash)
+	ret0, _ := ret[0].(storage.Address)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddressByString indicates an expected call of AddressByString.
+func (mr *MockIAddressMockRecorder) AddressByString(ctx, readableHash any) *MockIAddressAddressByStringCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddressByString", reflect.TypeOf((*MockIAddress)(nil).AddressByString), ctx, readableHash)
+	return &MockIAddressAddressByStringCall{Call: call}
+}
+
+// MockIAddressAddressByStringCall wrap *gomock.Call
+type MockIAddressAddressByStringCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockIAddressAddressByStringCall) Return(arg0 storage.Address, arg1 error) *MockIAddressAddressByStringCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockIAddressAddressByStringCall) Do(f func(context.Context, string) (storage.Address, error)) *MockIAddressAddressByStringCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockIAddressAddressByStringCall) DoAndReturn(f func(context.Context, string) (storage.Address, error)) *MockIAddressAddressByStringCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Balances mocks base method.
 func (m *MockIAddress) Balances(ctx context.Context, addressId uint64, limit, offset int) ([]storage.Balance, error) {
 	m.ctrl.T.Helper()

--- a/internal/storage/postgres/address.go
+++ b/internal/storage/postgres/address.go
@@ -144,6 +144,15 @@ func (a *Address) IdByAddress(ctx context.Context, address string, ids ...uint64
 	return
 }
 
+// AddressByString -
+func (a *Address) AddressByString(ctx context.Context, readableHash string) (address storage.Address, err error) {
+	err = a.DB().NewSelect().
+		Model(&address).
+		Where("address = ?", readableHash).
+		Scan(ctx)
+	return
+}
+
 // Balances -
 func (a *Address) Balances(ctx context.Context, addressId uint64, limit, offset int) (balances []storage.Balance, err error) {
 	query := a.DB().NewSelect().

--- a/internal/storage/postgres/address_test.go
+++ b/internal/storage/postgres/address_test.go
@@ -44,6 +44,19 @@ func (s *StorageTestSuite) TestIcaAddressByHash() {
 	s.Require().EqualValues("210", address.DefaultBalance.Spendable.String())
 }
 
+func (s *StorageTestSuite) TestAddressByString() {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer ctxCancel()
+
+	hash := []byte{48, 160, 217, 234, 151, 39, 229, 141, 230, 127, 49, 37, 182, 237, 136, 189, 218, 247, 87, 139, 87, 173, 20, 154, 154, 144, 84, 29, 23, 55, 212, 7}
+	address, err := s.storage.Address.AddressByString(ctx, "celestia1xzsdn65hyljcmenlxyjmdmvghhd0w4ut27k3fx56jp2p69eh6srs8p3rss")
+	s.Require().NoError(err)
+	s.Require().EqualValues(4, address.Id)
+	s.Require().EqualValues(101, address.Height)
+	s.Require().Equal("celestia1xzsdn65hyljcmenlxyjmdmvghhd0w4ut27k3fx56jp2p69eh6srs8p3rss", address.Address)
+	s.Require().Equal(hash, address.Hash)
+}
+
 func (s *StorageTestSuite) TestAddressByHashWithoutCelestials() {
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer ctxCancel()

--- a/internal/storage/postgres/scopes.go
+++ b/internal/storage/postgres/scopes.go
@@ -84,6 +84,13 @@ func txFilterWithoutLimit(query *bun.SelectQuery, fltrs storage.TxFilter) *bun.S
 	if fltrs.WithMessages {
 		query = query.Relation("Messages")
 	}
+
+	if !fltrs.WindowFrom.IsZero() {
+		query = query.Where("time >= ?", fltrs.WindowFrom)
+	}
+	if !fltrs.WindowTo.IsZero() {
+		query = query.Where("time <= ?", fltrs.WindowTo)
+	}
 	return query
 }
 

--- a/internal/storage/tx.go
+++ b/internal/storage/tx.go
@@ -54,6 +54,9 @@ type TxFilter struct {
 	TimeTo               time.Time
 	WithMessages         bool
 	Cursor               uint64
+
+	WindowFrom time.Time
+	WindowTo   time.Time
 }
 
 func (filter *TxFilter) IsEmpty() bool {


### PR DESCRIPTION
### What's changed

Optimizes the `GET /v1/address/{hash}/txs` endpoint by narrowing the transaction query to the time window in which the address was actually active, instead of scanning the whole `tx` hypertable.

- **`internal/storage/tx.go`** — added `WindowFrom` / `WindowTo` fields to `TxFilter`.
- **`internal/storage/postgres/scopes.go`** — `txFilterWithoutLimit` now applies `time >= WindowFrom` and `time <= WindowTo` conditions, allowing TimescaleDB to prune chunks outside the address activity window.
- **`internal/storage/address.go`, `postgres/address.go`** — new `IAddress.AddressByString(ctx, address)` method: fetches the address row by its bech32 string in a single query (replaces decode-hash + `IdByHash` lookup in the handler).
- **`cmd/api/handler/address.go`** — `Transactions` handler now:
  - resolves the address via `AddressByString`;
  - computes the query window from the address's first (`Height`) and last (`LastHeight`) activity blocks via `IBlock.Time`;
  - if the `height` query param is set, the window collapses to that single block's time.
- **`cmd/api/init.go`** — `NewAddressHandler` now receives `db.Blocks`.

### Tests

- Storage integration test `TestAddressByString`.
- Updated handler test `TestTransactions` with mocked `AddressByString` and `IBlock.Time`.
- Regenerated mock for `IAddress`.