### PR TITLE
Fix: websocket read on disconnected channel

### DIFF
--- a/cmd/api/handler/websocket/METRICS.md
+++ b/cmd/api/handler/websocket/METRICS.md
@@ -59,9 +59,9 @@ This document describes the Prometheus metrics exposed by the WebSocket implemen
 
 #### `websocket_unsubscribe_requests_total`
 - **Type**: Counter
-- **Labels**: `channel` (head, blocks, gas_price)
+- **Labels**: `channel` (head, blocks, gas_price), `status` (success, error)
 - **Description**: Total unsubscribe requests
-- **Use**: Track unsubscribe activity
+- **Use**: Track unsubscribe activity and success/error rate
 
 ### Error Metrics
 

--- a/cmd/api/handler/websocket/client.go
+++ b/cmd/api/handler/websocket/client.go
@@ -185,43 +185,61 @@ func (c *Client) ReadMessages(ctx context.Context, ws *websocket.Conn, log echo.
 		return ws.SetReadDeadline(time.Now().Add(pongWait))
 	})
 
+	defer func() {
+		if c.unsubscribeHandler != nil && c.filters != nil {
+			if c.filters.head {
+				c.unsubscribeHandler(ChannelHead, c)
+			}
+			if c.filters.blocks {
+				c.unsubscribeHandler(ChannelBlocks, c)
+			}
+			if c.filters.gasPrice {
+				c.unsubscribeHandler(ChannelGasPrice, c)
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		default:
-			if err := c.read(ws); err != nil {
-				timeoutErr, ok := err.(net.Error)
-
-				switch {
-				case err == io.EOF:
-					return
-				case errors.Is(err, websocket.ErrCloseSent):
-					return
-				case ok && timeoutErr.Timeout():
-					return
-				case websocket.IsCloseError(err,
-					websocket.CloseNormalClosure,
-					websocket.CloseAbnormalClosure,
-					websocket.CloseNoStatusReceived,
-					websocket.CloseGoingAway):
-					if c.unsubscribeHandler != nil {
-						c.unsubscribeHandler(ChannelHead, c)
-						c.unsubscribeHandler(ChannelBlocks, c)
-						c.unsubscribeHandler(ChannelGasPrice, c)
-					}
-					return
+			_, data, err := ws.ReadMessage()
+			if err != nil {
+				wsErrors.WithLabelValues("read").Inc()
+				if !isExpectedDisconnect(err) {
+					log.Errorf("read websocket message: %s", err.Error())
 				}
-				log.Errorf("read websocket message: %s", err.Error())
+				return
+			}
+
+			if err := c.handle(data); err != nil {
+				log.Errorf("handle websocket message: %s", err.Error())
+				c.Notify(errorMessage(err))
 			}
 		}
 	}
 }
 
-func (c *Client) read(ws *websocket.Conn) error {
+func isExpectedDisconnect(err error) bool {
+	if err == nil {
+		return false
+	}
+	timeoutErr, ok := err.(net.Error)
+	return err == io.EOF ||
+		errors.Is(err, websocket.ErrCloseSent) ||
+		(ok && timeoutErr.Timeout()) ||
+		websocket.IsCloseError(err,
+			websocket.CloseNormalClosure,
+			websocket.CloseAbnormalClosure,
+			websocket.CloseNoStatusReceived,
+			websocket.CloseGoingAway)
+}
+
+func (c *Client) handle(data []byte) error {
 	var msg Message
-	if err := ws.ReadJSON(&msg); err != nil {
-		wsErrors.WithLabelValues("read").Inc()
+	if err := json.Unmarshal(data, &msg); err != nil {
+		wsErrors.WithLabelValues("decode").Inc()
 		return err
 	}
 
@@ -239,7 +257,7 @@ func (c *Client) read(ws *websocket.Conn) error {
 func (c *Client) handleSubscribeMessage(msg Message) error {
 	var subscribeMsg Subscribe
 	if err := json.Unmarshal(msg.Body, &subscribeMsg); err != nil {
-		wsSubscribeRequests.WithLabelValues(subscribeMsg.Channel, "error").Inc()
+		wsSubscribeRequests.WithLabelValues("decode", "error").Inc()
 		return err
 	}
 
@@ -258,14 +276,16 @@ func (c *Client) handleSubscribeMessage(msg Message) error {
 func (c *Client) handleUnsubscribeMessage(msg Message) error {
 	var unsubscribeMsg Unsubscribe
 	if err := json.Unmarshal(msg.Body, &unsubscribeMsg); err != nil {
+		wsUnsubscribeRequests.WithLabelValues("decode", "error").Inc()
 		return err
 	}
 	if err := c.DetachFilters(unsubscribeMsg); err != nil {
+		wsUnsubscribeRequests.WithLabelValues(unsubscribeMsg.Channel, "error").Inc()
 		return err
 	}
 	if c.unsubscribeHandler != nil {
 		c.unsubscribeHandler(unsubscribeMsg.Channel, c)
 	}
-	wsUnsubscribeRequests.WithLabelValues(unsubscribeMsg.Channel).Inc()
+	wsUnsubscribeRequests.WithLabelValues(unsubscribeMsg.Channel, "success").Inc()
 	return nil
 }

--- a/cmd/api/handler/websocket/manager_test.go
+++ b/cmd/api/handler/websocket/manager_test.go
@@ -5,6 +5,7 @@ package websocket
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -14,10 +15,193 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
 
 const testIp = "10.0.0.1"
+
+func dialWS(t *testing.T, srv *httptest.Server) *websocket.Conn {
+	t.Helper()
+	wsUrl := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+	conn, resp, err := websocket.DefaultDialer.Dial(wsUrl, nil)
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+	require.NoError(t, err)
+	return conn
+}
+
+func subscribe(t *testing.T, conn *websocket.Conn, channel string) {
+	t.Helper()
+	require.NoError(t, conn.WriteJSON(Message{
+		Method: MethodSubscribe,
+		Body:   json.RawMessage(`{"channel":"` + channel + `","filters":{}}`),
+	}))
+}
+
+func unsubscribe(t *testing.T, conn *websocket.Conn, channel string) {
+	t.Helper()
+	require.NoError(t, conn.WriteJSON(Message{
+		Method: MethodUnsubscribe,
+		Body:   json.RawMessage(`{"channel":"` + channel + `"}`),
+	}))
+}
+
+// TestHandleUnsubscribeMetrics verifies that unsubscribe requests are accounted
+// with success/error status symmetrically with subscribe.
+func TestHandleUnsubscribeMetrics(t *testing.T) {
+	manager := NewManager(nil)
+	e := echo.New()
+	e.GET("/ws", manager.Handle)
+
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	successBase := testutil.ToFloat64(wsUnsubscribeRequests.WithLabelValues(ChannelHead, "success"))
+	unknownBase := testutil.ToFloat64(wsUnsubscribeRequests.WithLabelValues("unknown", "error"))
+
+	conn := dialWS(t, srv)
+	defer conn.Close()
+
+	subscribe(t, conn, ChannelHead)
+	require.Eventually(t, func() bool {
+		return manager.head.clients.Len() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	// valid unsubscribe -> success
+	unsubscribe(t, conn, ChannelHead)
+	require.Eventually(t, func() bool {
+		return manager.head.clients.Len() == 0
+	}, time.Second, 10*time.Millisecond, "client must be removed from the head channel")
+
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(wsUnsubscribeRequests.WithLabelValues(ChannelHead, "success")) == successBase+1
+	}, time.Second, 10*time.Millisecond, "successful unsubscribe must be counted with status=success")
+
+	// unknown channel -> error, the client is notified and the connection stays open
+	unsubscribe(t, conn, "unknown")
+	var errMsg ErrorMessage
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(time.Second)))
+	require.NoError(t, conn.ReadJSON(&errMsg))
+	require.Equal(t, ChannelError, errMsg.Channel)
+	require.Equal(t, ErrCodeUnknownChannel, errMsg.Body.Code)
+
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(wsUnsubscribeRequests.WithLabelValues("unknown", "error")) == unknownBase+1
+	}, time.Second, 10*time.Millisecond, "unsubscribe from unknown channel must be counted with status=error")
+}
+
+// TestHandleCleansUpSubscriptionsOnAbruptDisconnect verifies that an abrupt
+// connection drop (no close handshake) terminates the read loop and releases the
+// client from both the manager and the channels it was subscribed to. Before the
+// fix such errors fell through the switch and the loop span until gorilla panicked
+// with "repeated read on failed websocket connection".
+func TestHandleCleansUpSubscriptionsOnAbruptDisconnect(t *testing.T) {
+	manager := NewManager(nil)
+	e := echo.New()
+	e.GET("/ws", manager.Handle)
+
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	conn := dialWS(t, srv)
+	subscribe(t, conn, ChannelHead)
+
+	require.Eventually(t, func() bool {
+		return manager.head.clients.Len() == 1 && manager.clients.Len() == 1
+	}, time.Second, 10*time.Millisecond, "client must be registered in the head channel")
+
+	// drop the underlying tcp connection without a websocket close handshake
+	require.NoError(t, conn.UnderlyingConn().Close())
+
+	require.Eventually(t, func() bool {
+		return manager.head.clients.Len() == 0 && manager.clients.Len() == 0
+	}, 2*time.Second, 10*time.Millisecond, "subscriptions must be cleaned up after an abrupt disconnect")
+}
+
+// TestHandleDoesNotTouchUnsubscribedChannels verifies that disconnecting only
+// releases the channels the client actually subscribed to: the subscription gauge
+// of channels the client never subscribed to must stay untouched.
+func TestHandleDoesNotTouchUnsubscribedChannels(t *testing.T) {
+	manager := NewManager(nil)
+	e := echo.New()
+	e.GET("/ws", manager.Handle)
+
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	// wsSubscriptions is a package-global gauge, capture baselines and assert deltas
+	headBase := testutil.ToFloat64(wsSubscriptions.WithLabelValues(ChannelHead))
+	blocksBase := testutil.ToFloat64(wsSubscriptions.WithLabelValues(ChannelBlocks))
+	gasBase := testutil.ToFloat64(wsSubscriptions.WithLabelValues(ChannelGasPrice))
+
+	conn := dialWS(t, srv)
+	subscribe(t, conn, ChannelHead)
+
+	require.Eventually(t, func() bool {
+		return manager.head.clients.Len() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	require.Equal(t, 0, manager.blocks.clients.Len(), "client never subscribed to blocks")
+	require.Equal(t, 0, manager.gasPrice.clients.Len(), "client never subscribed to gas price")
+
+	require.NoError(t, conn.UnderlyingConn().Close())
+
+	require.Eventually(t, func() bool {
+		return manager.head.clients.Len() == 0
+	}, 2*time.Second, 10*time.Millisecond, "head subscription must be released after disconnect")
+
+	// the head gauge must return to baseline (inc on subscribe, dec on disconnect)
+	require.Equal(t, headBase, testutil.ToFloat64(wsSubscriptions.WithLabelValues(ChannelHead)))
+	// gauges of channels the client never subscribed to must be untouched
+	require.Equal(t, blocksBase, testutil.ToFloat64(wsSubscriptions.WithLabelValues(ChannelBlocks)), "blocks subscription gauge must not drift")
+	require.Equal(t, gasBase, testutil.ToFloat64(wsSubscriptions.WithLabelValues(ChannelGasPrice)), "gas price subscription gauge must not drift")
+}
+
+// TestHandleSurvivesApplicationLevelErrors verifies that malformed payloads and
+// unknown methods are logged but keep the connection alive: a subsequent valid
+// subscribe must still take effect.
+func TestHandleSurvivesApplicationLevelErrors(t *testing.T) {
+	manager := NewManager(nil)
+	e := echo.New()
+	e.GET("/ws", manager.Handle)
+
+	srv := httptest.NewServer(e)
+	defer srv.Close()
+
+	conn := dialWS(t, srv)
+	defer conn.Close()
+
+	readError := func(wantCode int) {
+		t.Helper()
+		var errMsg ErrorMessage
+		require.NoError(t, conn.SetReadDeadline(time.Now().Add(time.Second)))
+		require.NoError(t, conn.ReadJSON(&errMsg))
+		require.Equal(t, ChannelError, errMsg.Channel)
+		require.Equal(t, wantCode, errMsg.Body.Code)
+		require.NotEmpty(t, errMsg.Body.Message)
+	}
+
+	// malformed json: handle fails to decode, must not break the connection
+	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("{not a json")))
+	readError(ErrCodeInvalidMessage)
+
+	// unknown method: handle returns an error, but the connection must stay open
+	require.NoError(t, conn.WriteJSON(Message{Method: "unknown", Body: json.RawMessage(`{}`)}))
+	readError(ErrCodeUnknownMethod)
+
+	// unknown channel: handle returns an error, but the connection must stay open
+	require.NoError(t, conn.WriteJSON(Message{Method: MethodSubscribe, Body: json.RawMessage(`{"channel":"unknown","filters":{}}`)}))
+	readError(ErrCodeUnknownChannel)
+
+	// the connection must still be usable
+	subscribe(t, conn, ChannelHead)
+
+	require.Eventually(t, func() bool {
+		return manager.head.clients.Len() == 1
+	}, time.Second, 10*time.Millisecond, "connection must survive application-level errors")
+}
 
 func TestIpsCheckAndSetLimit(t *testing.T) {
 	ips := NewIps(3)

--- a/cmd/api/handler/websocket/messages.go
+++ b/cmd/api/handler/websocket/messages.go
@@ -5,6 +5,7 @@ package websocket
 
 import (
 	"encoding/json"
+	"errors"
 
 	"github.com/celenium-io/celestia-indexer/cmd/api/handler/responses"
 )
@@ -20,20 +21,21 @@ const (
 	ChannelHead     = "head"
 	ChannelBlocks   = "blocks"
 	ChannelGasPrice = "gas_price"
+	ChannelError    = "error"
 )
 
 type Message struct {
-	Method string          `json:"method" validate:"required,oneof=subscribe,unsubscribe"`
+	Method string          `json:"method" validate:"required,oneof=subscribe unsubscribe"`
 	Body   json.RawMessage `json:"body"   validate:"required"`
 }
 
 type Subscribe struct {
-	Channel string          `json:"channel" validate:"required,oneof=head tx"`
+	Channel string          `json:"channel" validate:"required,oneof=head blocks gas_price"`
 	Filters json.RawMessage `json:"filters" validate:"required"`
 }
 
 type Unsubscribe struct {
-	Channel string `json:"channel" validate:"required,oneof=head tx"`
+	Channel string `json:"channel" validate:"required,oneof=head blocks gas_price"`
 }
 
 type TransactionFilters struct {
@@ -72,5 +74,60 @@ func NewGasPriceNotification(value responses.GasPrice) Notification[*responses.G
 	return Notification[*responses.GasPrice]{
 		Channel: ChannelGasPrice,
 		Body:    &value,
+	}
+}
+
+// error codes reported to the client. Codes are stable and safe to expose;
+// internal error details are never sent to the client to avoid leaking
+// sensitive information.
+const (
+	ErrCodeInvalidMessage = 1
+	ErrCodeUnknownMethod  = 2
+	ErrCodeUnknownChannel = 3
+)
+
+// ErrorMessage is sent to the client when an incoming message cannot be handled.
+type ErrorMessage struct {
+	Channel string    `json:"channel"`
+	Body    ErrorBody `json:"body"`
+}
+
+type ErrorBody struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (m ErrorMessage) GetChannel() string {
+	return m.Channel
+}
+
+func newErrorMessage(code int, message string) ErrorMessage {
+	return ErrorMessage{
+		Channel: ChannelError,
+		Body: ErrorBody{
+			Code:    code,
+			Message: message,
+		},
+	}
+}
+
+// predefined client-facing errors
+var (
+	errInvalidMessage = newErrorMessage(ErrCodeInvalidMessage, "invalid message")
+	errUnknownMethod  = newErrorMessage(ErrCodeUnknownMethod, "unknown method")
+	errUnknownChannel = newErrorMessage(ErrCodeUnknownChannel, "unknown channel")
+)
+
+// errorMessage maps an internal error to a safe, predefined client-facing message.
+// Unmapped errors fall back to a generic "invalid message" so that internal
+// details are never exposed.
+func errorMessage(err error) ErrorMessage {
+	switch {
+	case errors.Is(err, ErrUnknownMethod):
+		return errUnknownMethod
+	case errors.Is(err, ErrUnknownChannel):
+		return errUnknownChannel
+	default:
+		return errInvalidMessage
 	}
 }

--- a/cmd/api/handler/websocket/metrics.go
+++ b/cmd/api/handler/websocket/metrics.go
@@ -51,13 +51,13 @@ var (
 	wsUnsubscribeRequests = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "websocket_unsubscribe_requests_total",
 		Help: "Total number of unsubscribe requests",
-	}, []string{"channel"})
+	}, []string{"channel", "status"}) // status: success, error
 
 	// Error metrics
 	wsErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "websocket_errors_total",
 		Help: "Total number of WebSocket errors",
-	}, []string{"type"}) // type: read, write, upgrade, unknown_method, unknown_channel
+	}, []string{"type"}) // type: read, decode, write, upgrade, unknown_method, unknown_channel
 
 	// Connection duration
 	wsConnectionDuration = promauto.NewHistogram(prometheus.HistogramOpts{

--- a/cmd/api/markdown/websocket.md
+++ b/cmd/api/markdown/websocket.md
@@ -82,3 +82,25 @@ To unsubscribe send `unsubscribe` message containing one of channel name describ
     }
 }
 ```
+
+### Errors
+
+If an incoming message can not be handled (malformed payload, unknown method or unknown channel), the server replies with a notification in the `error` channel. The connection stays open. Internal error details are never exposed; only a stable error code and a generic message are sent.
+
+```json
+{
+    "channel": "error",
+    "body": {
+        "code": 2,
+        "message": "unknown method"
+    }
+}
+```
+
+Supported error codes:
+
+| Code | Message           | Description                                                          |
+|------|-------------------|---------------------------------------------------------------------|
+| 1    | `invalid message` | The message could not be parsed (malformed JSON or invalid payload). |
+| 2    | `unknown method`  | The `method` field is not `subscribe` or `unsubscribe`.             |
+| 3    | `unknown channel` | The requested channel is not one of `head`, `blocks`, `gas_price`.  |

--- a/go.mod
+++ b/go.mod
@@ -247,6 +247,7 @@ require (
 	github.com/klauspost/reedsolomon v1.13.3 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labstack/gommon v0.5.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/linxGnu/grocksdb v1.9.8 // indirect


### PR DESCRIPTION
## Fix websocket read loop spinning on a failed connection

### Problem

The public API was emitting `fatal` Sentry events with `panic: repeated read on failed websocket connection`, originating from `gorilla/websocket`'s `(*Conn).NextReader`.

The read loop in `(*Client).ReadMessages` only returned on a handful of enumerated close codes (`io.EOF`, `ErrCloseSent`, timeouts, a few `CloseError` codes). Any other read error (e.g. an abrupt drop through a proxy/Cloudflare with an unexpected close code) fell through, got logged, and the loop iterated again. Once `gorilla` has set its internal `readErr`, every subsequent read returns immediately without blocking — so the loop span at full speed and `gorilla` panics after 1000 such reads. Each broken connection produced ~1000 log lines plus a panic.

### Changes

**Read loop (`client.go`)**
- Switched from `ReadJSON` to `ReadMessage` + explicit decode, so connection-level read errors are cleanly separated from message-handling errors.
- **Any** read error now terminates the loop — the busy-loop and the resulting panic are impossible.
- Application-level errors (malformed payload, unknown method/channel) are logged and the connection stays open.
- Disconnect cleanup now runs via `defer` and only releases the channels the client was actually subscribed to (using `c.filters`), fixing a subscription leak on `EOF`/timeout disconnects and keeping the `websocket_subscriptions` gauge from drifting negative.
- Expected disconnects are no longer logged as errors (`isExpectedDisconnect`).

**Client-facing error notifications (`messages.go`)**
- On a handling error the client now receives a notification on a new `error` channel with a **stable error code** and a generic message. Internal error text is never exposed to avoid leaking sensitive information; full details stay in the logs.
- Codes: `1 invalid message`, `2 unknown method`, `3 unknown channel`.

**Metrics (`metrics.go`)**
- Added a `decode` value to `websocket_errors_total{type}` for payload decode failures.
- Subscribe/unsubscribe decode errors are now attributed to a `decode` channel label instead of an empty string.
- `websocket_unsubscribe_requests_total` gained a `status` (success/error) label, symmetric with the subscribe metric.

**Validation tags (`messages.go`)**
- Updated stale `oneof=head tx` channel tags to the actual channels `head blocks gas_price`.
- Fixed `oneof=subscribe,unsubscribe` → `oneof=subscribe unsubscribe` (comma was a single invalid token for the validator).

**Docs**
- `cmd/api/markdown/websocket.md`: documented the `error` channel and the error-code table.
- `METRICS.md`: updated the unsubscribe metric labels.

### Tests

Added integration tests (real `httptest` websocket server) covering:
- abrupt disconnect terminates the read loop and cleans up subscriptions (regression for the panic + leak);
- disconnect does not touch the gauges of channels the client never subscribed to (asserted via `testutil.ToFloat64`);
- malformed JSON / unknown method / unknown channel keep the connection alive and return the correct error code;
- unsubscribe success/error are accounted with the new `status` label.

### Notes for reviewers
- `go.mod` gains one indirect test-only dependency (`kylelemons/godebug`, pulled in by `prometheus/.../testutil`).
- `websocket_unsubscribe_requests_total` now has an extra `status` label — `rate(...[5m])` queries keep working, but dashboards/alerts that match an exact label set should be double-checked.