### PR TITLE
Refactor: introduce `Cursor` for event parsing

### DIFF
--- a/pkg/indexer/parser/cursor_golden_test.go
+++ b/pkg/indexer/parser/cursor_golden_test.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2025 Bb Strategy Pte. Ltd. <celenium@baking-bad.org>
+// SPDX-License-Identifier: MIT
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/celenium-io/celestia-indexer/internal/storage"
+	storageTypes "github.com/celenium-io/celestia-indexer/internal/storage/types"
+	"github.com/celenium-io/celestia-indexer/pkg/indexer/config"
+	dCtx "github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
+	pkgTypes "github.com/celenium-io/celestia-indexer/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCursorGolden pins down the exact output of parseTxs on a real production
+// block (height 8880520) whose first transaction carries nine messages —
+// one MsgUpdateClient followed by eight consecutive MsgRecvPacket — sharing a
+// single events cursor across message boundaries.
+//
+// This is the scenario the events-cursor refactor (idx *int -> Cursor) is
+// riskiest for: eight same-type messages in a row exercise the "module"-keyed
+// IBC dispatch (handle/ibcEventHandlers) repeatedly, back to back, with no
+// other message type in between to reset any accidental shared state. If the
+// refactor shifts the cursor by even one event, message count, positions, or
+// the derived IBC channel state will diverge from the values captured here on
+// the pre-refactor code, and this test will fail.
+//
+// The expected values below were captured from the current (pre-refactor)
+// parser output, not derived from first principles — treat them as a
+// snapshot to preserve, not as a spec to re-derive.
+func TestCursorGolden(t *testing.T) {
+	block, err := getBlockByHeight(8880520)
+	require.NoError(t, err)
+
+	decodeCtx := dCtx.NewContext()
+	decodeCtx.Block = &storage.Block{
+		Height:       8880520,
+		MessageTypes: storageTypes.NewMsgTypeBitMask(),
+	}
+
+	p := NewModule(config.Indexer{})
+	resultTxs, err := p.parseTxs(decodeCtx, &block)
+	require.NoError(t, err)
+	require.Len(t, resultTxs, 5)
+
+	// tx0: MsgUpdateClient + 8x MsgRecvPacket sharing one cursor.
+	tx0 := resultTxs[0]
+	require.Equal(t, storageTypes.StatusSuccess, tx0.Status)
+	require.Empty(t, tx0.Error)
+	require.EqualValues(t, 4998079, tx0.GasUsed)
+	require.EqualValues(t, 5999331, tx0.GasWanted)
+	require.ElementsMatch(t, []storageTypes.MsgType{
+		storageTypes.MsgUpdateClient,
+		storageTypes.MsgRecvPacket,
+	}, tx0.MessageTypes.Names())
+
+	require.Equal(t, storageTypes.StatusSuccess, resultTxs[1].Status)
+	require.ElementsMatch(t, []storageTypes.MsgType{storageTypes.IBCTransfer}, resultTxs[1].MessageTypes.Names())
+
+	for i := 2; i <= 4; i++ {
+		require.Equal(t, storageTypes.StatusSuccess, resultTxs[i].Status)
+		require.ElementsMatch(t, []storageTypes.MsgType{storageTypes.MsgPayForBlobs}, resultTxs[i].MessageTypes.Names())
+	}
+
+	// The cursor must split tx0's shared event slice into exactly nine
+	// distinct messages, in order, each with its own position — not merge
+	// adjacent MsgRecvPacket messages together or drop/duplicate one.
+	require.Len(t, decodeCtx.Messages, 13)
+
+	wantTypes := []storageTypes.MsgType{
+		storageTypes.MsgUpdateClient,
+		storageTypes.MsgRecvPacket, storageTypes.MsgRecvPacket, storageTypes.MsgRecvPacket, storageTypes.MsgRecvPacket,
+		storageTypes.MsgRecvPacket, storageTypes.MsgRecvPacket, storageTypes.MsgRecvPacket, storageTypes.MsgRecvPacket,
+		storageTypes.IBCTransfer,
+		storageTypes.MsgPayForBlobs, storageTypes.MsgPayForBlobs, storageTypes.MsgPayForBlobs,
+	}
+	wantPositions := []int64{0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0}
+	for i, msg := range decodeCtx.Messages {
+		require.Equalf(t, wantTypes[i], msg.Type, "message %d type", i)
+		require.Equalf(t, wantPositions[i], msg.Position, "message %d position", i)
+		require.Equalf(t, pkgTypes.Level(8880520), msg.Height, "message %d height", i)
+		require.Emptyf(t, msg.InternalMsgs, "message %d must not have internal msgs", i)
+	}
+
+	// The eight MsgRecvPacket handlers converge on a single IBC channel
+	// derived from the packets' shared destination channel.
+	require.Equal(t, 1, decodeCtx.IbcChannels.Len())
+	channel, ok := decodeCtx.IbcChannels.Get("channel-4")
+	require.True(t, ok)
+	require.Equal(t, storageTypes.IbcChannelStatusInitialization, channel.Status)
+	require.Equal(t, "200176", channel.Received.String())
+	require.True(t, channel.Sent.IsZero())
+	require.EqualValues(t, 1, channel.TransfersCount)
+
+	// Every in-flight transfer opened during processing was resolved
+	// (matched to a fungible-token-packet event or explicitly discarded) by
+	// the time parseTxs returns — none should be left dangling.
+	require.Empty(t, decodeCtx.IbcTransfers)
+
+	require.Equal(t, 71, decodeCtx.Addresses.Len())
+	require.Len(t, decodeCtx.BlobLogs, 32)
+	require.Len(t, decodeCtx.Events, 356)
+	require.ElementsMatch(t, []storageTypes.MsgType{
+		storageTypes.MsgPayForBlobs,
+		storageTypes.IBCTransfer,
+		storageTypes.MsgUpdateClient,
+		storageTypes.MsgRecvPacket,
+	}, decodeCtx.Block.MessageTypes.Names())
+}

--- a/pkg/indexer/parser/events/acknowledgement.go
+++ b/pkg/indexer/parser/events/acknowledgement.go
@@ -12,24 +12,26 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleAcknowledgement(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleAcknowledgement(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	action := decoder.StringFromMap(events[*idx].Data, "action")
+	event, _ := c.Peek()
+	action := decoder.StringFromMap(event.Data, "action")
 	isValidMsg := action == "/ibc.core.channel.v1.MsgAcknowledgement"
 	if !isValidMsg {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processAcknowledgement(ctx, events, msg, idx)
+	c.Next()
+	return processAcknowledgement(ctx, c, msg)
 }
 
-func processAcknowledgement(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if len(events)-1 < *idx || events[*idx].Type == storageTypes.EventTypeMessage {
+func processAcknowledgement(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	event, ok := c.Peek()
+	if !ok || event.Type == storageTypes.EventTypeMessage {
 		ctx.RemoveLastIbcTransfer()
 		return nil
 	}
@@ -60,13 +62,14 @@ func processAcknowledgement(ctx *context.Context, events []storage.Event, msg *s
 			if err != nil {
 				return errors.Wrap(err, "decode message in Acknowledgement")
 			}
-			if err := handle(ctx, events, &decodedMsg.Msg, idx, ibcEventHandlers, "module"); err != nil {
+			if err := handle(ctx, c, &decodedMsg.Msg, ibcEventHandlers, "module"); err != nil {
 				return errors.Wrap(err, "handle IBC msg event")
 			}
 		}
 
 	case "transfer":
-		var action = decoder.StringFromMap(events[*idx].Data, "action")
+		current, _ := c.Peek()
+		action := decoder.StringFromMap(current.Data, "action")
 
 		transfer := ctx.GetLastIbcTransfer()
 		if transfer == nil {
@@ -83,10 +86,15 @@ func processAcknowledgement(ctx *context.Context, events []storage.Event, msg *s
 			hasFtp bool
 			chanId string
 		)
-		for action == "" && len(events)-1 > *idx {
-			switch events[*idx].Type {
+		for action == "" {
+			if len(c.Remaining()) <= 1 {
+				break
+			}
+
+			event, _ := c.Peek()
+			switch event.Type {
 			case storageTypes.EventTypeAcknowledgePacket:
-				ack, err := decode.NewAcknowledgementPacket(events[*idx].Data)
+				ack, err := decode.NewAcknowledgementPacket(event.Data)
 				if err != nil {
 					return errors.Wrap(err, "ack packet")
 				}
@@ -94,14 +102,16 @@ func processAcknowledgement(ctx *context.Context, events []storage.Event, msg *s
 				chanId = ack.PacketSrcChannel
 			case storageTypes.EventTypeFungibleTokenPacket:
 				hasFtp = true
-				ftp := decode.NewFungibleTokenPacket(events[*idx].Data)
+				ftp := decode.NewFungibleTokenPacket(event.Data)
 				if ftp.Error != "" {
 					ctx.RemoveLastIbcTransfer()
 					ctx.DeleteIbcChannel(chanId)
 				}
 			}
-			*idx += 1
-			action = decoder.StringFromMap(events[*idx].Data, "action")
+
+			c.Next()
+			next, _ := c.Peek()
+			action = decoder.StringFromMap(next.Data, "action")
 		}
 
 		if !hasFtp {

--- a/pkg/indexer/parser/events/acknowledgement_test.go
+++ b/pkg/indexer/parser/events/acknowledgement_test.go
@@ -21,7 +21,7 @@ func Test_handleAcknowledgement(t *testing.T) {
 		events   []storage.Event
 		transfer *storage.IbcTransfer
 		msg      []*storage.Message
-		idx      *int
+		idx      int
 
 		isTransferNil bool
 	}{
@@ -127,7 +127,7 @@ func Test_handleAcknowledgement(t *testing.T) {
 					},
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		}, {
 			name:          "test 2",
 			ctx:           context.NewContext(),
@@ -226,7 +226,7 @@ func Test_handleAcknowledgement(t *testing.T) {
 					},
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		}, {
 			name:          "test 3",
 			ctx:           context.NewContext(),
@@ -369,14 +369,16 @@ func Test_handleAcknowledgement(t *testing.T) {
 					},
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for i := range tt.msg {
 				tt.ctx.AddIbcTransfer(tt.transfer)
-				err := handleAcknowledgement(tt.ctx, tt.events, tt.msg[i], tt.idx)
+				c := NewCursor(tt.events)
+				c.Skip(tt.idx)
+				err := handleAcknowledgement(tt.ctx, c, tt.msg[i])
 				require.NoError(t, err)
 				if tt.isTransferNil {
 					require.Empty(t, tt.ctx.IbcTransfers)

--- a/pkg/indexer/parser/events/boundary_test.go
+++ b/pkg/indexer/parser/events/boundary_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -20,7 +19,6 @@ func Test_recvPacket_boundaryChecks(t *testing.T) {
 		ctx         *context.Context
 		events      []storage.Event
 		msg         *storage.Message
-		idx         *int
 		expectError bool
 	}{
 		{
@@ -40,7 +38,6 @@ func Test_recvPacket_boundaryChecks(t *testing.T) {
 				Height: 100,
 				Data:   map[string]any{},
 			},
-			idx:         testsuite.Ptr(0),
 			expectError: false, // should handle gracefully
 		},
 		{
@@ -67,7 +64,6 @@ func Test_recvPacket_boundaryChecks(t *testing.T) {
 				Height: 100,
 				Data:   map[string]any{},
 			},
-			idx:         testsuite.Ptr(0),
 			expectError: false,
 		},
 		{
@@ -94,14 +90,14 @@ func Test_recvPacket_boundaryChecks(t *testing.T) {
 				Height: 100,
 				Data:   map[string]any{},
 			},
-			idx:         testsuite.Ptr(0),
 			expectError: false, // should not panic on boundary
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := handleRecvPacket(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			err := handleRecvPacket(tt.ctx, c, tt.msg)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {
@@ -118,7 +114,6 @@ func Test_acknowledgement_boundaryChecks(t *testing.T) {
 		ctx         *context.Context
 		events      []storage.Event
 		msg         *storage.Message
-		idx         *int
 		expectError bool
 	}{
 		{
@@ -138,7 +133,6 @@ func Test_acknowledgement_boundaryChecks(t *testing.T) {
 				Height: 100,
 				Data:   map[string]any{},
 			},
-			idx:         testsuite.Ptr(0),
 			expectError: false,
 		},
 		{
@@ -163,7 +157,6 @@ func Test_acknowledgement_boundaryChecks(t *testing.T) {
 				Height: 100,
 				Data:   map[string]any{},
 			},
-			idx:         testsuite.Ptr(0),
 			expectError: false,
 		},
 		{
@@ -202,14 +195,14 @@ func Test_acknowledgement_boundaryChecks(t *testing.T) {
 					},
 				},
 			},
-			idx:         testsuite.Ptr(0),
 			expectError: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := handleAcknowledgement(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			err := handleAcknowledgement(tt.ctx, c, tt.msg)
 			if tt.expectError {
 				require.Error(t, err)
 			} else {
@@ -305,24 +298,23 @@ func Test_exec_outOfBounds(t *testing.T) {
 	}
 }
 
-// Test_toTheNextAction_boundaryChecks tests toTheNextAction boundary conditions
+// Test_toTheNextAction_boundaryChecks tests Cursor.SkipToNext("action") boundary
+// conditions (this used to test the standalone toTheNextAction helper, which
+// SkipToNext replaced).
 func Test_toTheNextAction_boundaryChecks(t *testing.T) {
 	tests := []struct {
 		name           string
 		events         []storage.Event
-		initialIdx     int
-		expectedIdx    int
-		shouldNotPanic bool
+		wantAtEnd      bool // Peek() should report false after SkipToNext
+		wantActionData string
 	}{
 		{
-			name:           "index at end of array",
-			events:         []storage.Event{},
-			initialIdx:     0,
-			expectedIdx:    0,
-			shouldNotPanic: true,
+			name:      "index at end of array",
+			events:    []storage.Event{},
+			wantAtEnd: true,
 		},
 		{
-			name: "index one before end",
+			name: "single event with empty action is drained, cursor ends at EOF",
 			events: []storage.Event{
 				{
 					Type: "message",
@@ -331,12 +323,10 @@ func Test_toTheNextAction_boundaryChecks(t *testing.T) {
 					},
 				},
 			},
-			initialIdx:     0,
-			expectedIdx:    0,
-			shouldNotPanic: true,
+			wantAtEnd: true,
 		},
 		{
-			name: "normal progression",
+			name: "normal progression stops at the boundary event, unconsumed",
 			events: []storage.Event{
 				{
 					Type: "message",
@@ -351,12 +341,11 @@ func Test_toTheNextAction_boundaryChecks(t *testing.T) {
 					},
 				},
 			},
-			initialIdx:     0,
-			expectedIdx:    1,
-			shouldNotPanic: true,
+			wantAtEnd:      false,
+			wantActionData: "/some.action",
 		},
 		{
-			name: "all empty actions until end",
+			name: "all empty actions until end drains everything",
 			events: []storage.Event{
 				{
 					Type: "message",
@@ -371,21 +360,24 @@ func Test_toTheNextAction_boundaryChecks(t *testing.T) {
 					},
 				},
 			},
-			initialIdx:     0,
-			expectedIdx:    1,
-			shouldNotPanic: true,
+			wantAtEnd: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			idx := tt.initialIdx
+			c := NewCursor(tt.events)
 			require.NotPanics(t, func() {
-				toTheNextAction(tt.events, &idx)
+				c.SkipToNext("action")
 			})
-			if tt.shouldNotPanic {
-				require.Equal(t, tt.expectedIdx, idx)
+
+			event, ok := c.Peek()
+			if tt.wantAtEnd {
+				require.False(t, ok, "cursor should have reached the end")
+				return
 			}
+			require.True(t, ok)
+			require.Equal(t, tt.wantActionData, event.Data["action"])
 		})
 	}
 }
@@ -408,15 +400,15 @@ func Test_handlers_nilChecks(t *testing.T) {
 		Data:   map[string]any{},
 	}
 
-	t.Run("nil index pointer", func(t *testing.T) {
-		err := handleRecvPacket(ctx, events, msg, nil)
+	t.Run("nil cursor", func(t *testing.T) {
+		err := handleRecvPacket(ctx, nil, msg)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "nil event index")
+		require.Contains(t, err.Error(), "nil event cursor")
 	})
 
 	t.Run("nil message pointer", func(t *testing.T) {
-		idx := 0
-		err := handleRecvPacket(ctx, events, nil, &idx)
+		c := NewCursor(events)
+		err := handleRecvPacket(ctx, c, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "nil message")
 	})
@@ -428,7 +420,6 @@ func Test_acknowledgement_loopIncrementSafety(t *testing.T) {
 		name   string
 		events []storage.Event
 		msg    *storage.Message
-		idx    int
 	}{
 		{
 			name: "increment at exact boundary",
@@ -457,16 +448,15 @@ func Test_acknowledgement_loopIncrementSafety(t *testing.T) {
 					},
 				},
 			},
-			idx: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.NewContext()
-			idx := tt.idx
+			c := NewCursor(tt.events)
 			require.NotPanics(t, func() {
-				err := handleAcknowledgement(ctx, tt.events, tt.msg, &idx)
+				err := handleAcknowledgement(ctx, c, tt.msg)
 				require.NoError(t, err)
 			})
 		})

--- a/pkg/indexer/parser/events/cancel_unbonding.go
+++ b/pkg/indexer/parser/events/cancel_unbonding.go
@@ -14,39 +14,42 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleCancelUnbonding(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleCancelUnbonding(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processCancelUnbonding(ctx, events, msg, idx)
+	c.Next()
+	return processCancelUnbonding(ctx, c, msg)
 }
 
-func processCancelUnbonding(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	var (
-		msgIdx    = decoder.StringFromMap(events[*idx].Data, "msg_index")
-		newFormat = msgIdx != ""
-	)
+func processCancelUnbonding(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	first, _ := c.Peek()
+	msgIdx := decoder.StringFromMap(first.Data, "msg_index")
+	newFormat := msgIdx != ""
 
-	for i := *idx; i < len(events); i++ {
-		switch events[i].Type {
+	for {
+		event, ok := c.Next()
+		if !ok {
+			return nil
+		}
+		switch event.Type {
 		case storageTypes.EventTypeMessage:
-			if module := decoder.StringFromMap(events[i].Data, "module"); module == storageTypes.ModuleNameStaking.String() {
-				*idx = i + 1
+			if module := decoder.StringFromMap(event.Data, "module"); module == storageTypes.ModuleNameStaking.String() {
 				return nil
 			}
 		case storageTypes.EventTypeWithdrawRewards:
-			if err := parseWithdrawRewards(ctx, msg, events[i].Data); err != nil {
+			if err := parseWithdrawRewards(ctx, msg, event.Data); err != nil {
 				return err
 			}
 		case storageTypes.EventTypeCancelUnbondingDelegation:
-			cancel, err := decode.NewCancelUnbondingDelegation(events[i].Data)
+			cancel, err := decode.NewCancelUnbondingDelegation(event.Data)
 			if err != nil {
 				return err
 			}
@@ -112,11 +115,8 @@ func processCancelUnbonding(ctx *context.Context, events []storage.Event, msg *s
 			})
 
 			if newFormat {
-				*idx = i + 1
 				return nil
 			}
 		}
 	}
-
-	return nil
 }

--- a/pkg/indexer/parser/events/cancel_unbonding_test.go
+++ b/pkg/indexer/parser/events/cancel_unbonding_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/celenium-io/celestia-indexer/internal/currency"
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +21,8 @@ func Test_handleCancelUnbonding(t *testing.T) {
 		ctx    *context.Context
 		events []storage.Event
 		msg    *storage.Message
-		idx    *int
+		idx    int
+
 		cancel *storage.Undelegation
 	}{
 		{
@@ -136,7 +136,8 @@ func Test_handleCancelUnbonding(t *testing.T) {
 					"ValidatorAddress": "celestiavaloper1qe8uuf5x69c526h4nzxwv4ltftr73v7q5qhs58",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			cancel: &storage.Undelegation{
 				Height: 844287,
 				Time:   ts,
@@ -174,7 +175,9 @@ func Test_handleCancelUnbonding(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := handleCancelUnbonding(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			c.Skip(tt.idx)
+			err := handleCancelUnbonding(tt.ctx, c, tt.msg)
 			require.NoError(t, err)
 			require.Len(t, tt.ctx.CancelUnbonding, 1)
 			require.Equal(t, *tt.cancel, tt.ctx.CancelUnbonding[0])

--- a/pkg/indexer/parser/events/channel_close.go
+++ b/pkg/indexer/parser/events/channel_close.go
@@ -12,31 +12,33 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleChannelClose(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleChannelClose(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	action := decoder.StringFromMap(events[*idx].Data, "action")
+	event, _ := c.Peek()
+	action := decoder.StringFromMap(event.Data, "action")
 	isValidMsg := action == "/ibc.core.channel.v1.MsgChannelCloseConfirm" || action == "/ibc.core.channel.v1.MsgChannelCloseInit"
 
 	if !isValidMsg {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processChannelClose(ctx, events, msg, idx)
+	c.Next()
+	return processChannelClose(ctx, c, msg)
 }
 
-func processChannelClose(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if len(events) <= *idx {
+func processChannelClose(ctx *context.Context, c *Cursor, _ *storage.Message) error {
+	event, ok := c.Peek()
+	if !ok {
 		return errors.New("not enough events for channel close")
 	}
-	if events[*idx].Type != storageTypes.EventTypeChannelCloseConfirm {
-		return errors.Errorf("invalid event type: %s", events[*idx].Type)
+	if event.Type != storageTypes.EventTypeChannelCloseConfirm {
+		return errors.Errorf("invalid event type: %s", event.Type)
 	}
-	cc := decode.NewChannelChange(events[*idx].Data)
+	cc := decode.NewChannelChange(event.Data)
 
 	ibcChannel := &storage.IbcChannel{
 		Id:     cc.ChannelId,

--- a/pkg/indexer/parser/events/channel_open_confirm.go
+++ b/pkg/indexer/parser/events/channel_open_confirm.go
@@ -12,31 +12,33 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleChannelOpenConfirm(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleChannelOpenConfirm(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	action := decoder.StringFromMap(events[*idx].Data, "action")
+	event, _ := c.Peek()
+	action := decoder.StringFromMap(event.Data, "action")
 	isValidMsg := action == "/ibc.core.channel.v1.MsgChannelOpenConfirm" || action == "/ibc.core.channel.v1.MsgChannelOpenAck"
 
 	if !isValidMsg {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processChannelOpenConfirm(ctx, events, msg, idx)
+	c.Next()
+	return processChannelOpenConfirm(ctx, c, msg)
 }
 
-func processChannelOpenConfirm(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if len(events) <= *idx {
+func processChannelOpenConfirm(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	event, ok := c.Peek()
+	if !ok {
 		return errors.New("not enough events for channel confirm")
 	}
-	if events[*idx].Type != storageTypes.EventTypeChannelOpenConfirm && events[*idx].Type != storageTypes.EventTypeChannelOpenAck {
-		return errors.Errorf("invalid event type: %s", events[*idx].Type)
+	if event.Type != storageTypes.EventTypeChannelOpenConfirm && event.Type != storageTypes.EventTypeChannelOpenAck {
+		return errors.Errorf("invalid event type: %s", event.Type)
 	}
-	cc := decode.NewChannelChange(events[*idx].Data)
+	cc := decode.NewChannelChange(event.Data)
 
 	ibcChannel := &storage.IbcChannel{
 		Id:                    cc.ChannelId,
@@ -51,6 +53,6 @@ func processChannelOpenConfirm(ctx *context.Context, events []storage.Event, msg
 	}
 	ctx.AddIbcChannel(ibcChannel)
 
-	*idx += 2
+	c.Skip(2)
 	return nil
 }

--- a/pkg/indexer/parser/events/channel_open_confirm_test.go
+++ b/pkg/indexer/parser/events/channel_open_confirm_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +18,7 @@ func Test_handleChannelOpenConfirm(t *testing.T) {
 		ctx    *context.Context
 		events []storage.Event
 		msg    []*storage.Message
-		idx    *int
+		idx    int
 	}{
 		{
 			name: "test 1",
@@ -81,13 +80,15 @@ func Test_handleChannelOpenConfirm(t *testing.T) {
 					Height: 1163656,
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for i := range tt.msg {
-				err := handleChannelOpenConfirm(tt.ctx, tt.events, tt.msg[i], tt.idx)
+				c := NewCursor(tt.events)
+				c.Skip(tt.idx)
+				err := handleChannelOpenConfirm(tt.ctx, c, tt.msg[i])
 				require.NoError(t, err)
 
 				for _, value := range tt.ctx.IbcChannels.All() {

--- a/pkg/indexer/parser/events/channel_open_init.go
+++ b/pkg/indexer/parser/events/channel_open_init.go
@@ -12,31 +12,33 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleChannelOpenInit(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleChannelOpenInit(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	action := decoder.StringFromMap(events[*idx].Data, "action")
+	event, _ := c.Peek()
+	action := decoder.StringFromMap(event.Data, "action")
 	isValidMsg := action == "/ibc.core.channel.v1.MsgChannelOpenInit" || action == "/ibc.core.channel.v1.MsgChannelOpenTry"
 
 	if !isValidMsg {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processChannelOpenInit(ctx, events, msg, idx)
+	c.Next()
+	return processChannelOpenInit(ctx, c, msg)
 }
 
-func processChannelOpenInit(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if len(events) <= *idx {
+func processChannelOpenInit(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	event, ok := c.Peek()
+	if !ok {
 		return errors.New("not enough events for channel open init")
 	}
-	if events[*idx].Type != storageTypes.EventTypeChannelOpenInit && events[*idx].Type != storageTypes.EventTypeChannelOpenTry {
-		return errors.Errorf("invalid event type: %s", events[*idx].Type)
+	if event.Type != storageTypes.EventTypeChannelOpenInit && event.Type != storageTypes.EventTypeChannelOpenTry {
+		return errors.Errorf("invalid event type: %s", event.Type)
 	}
-	cc := decode.NewChannelChange(events[*idx].Data)
+	cc := decode.NewChannelChange(event.Data)
 
 	channelSettings, ok := msg.Data["Channel"]
 	if !ok {

--- a/pkg/indexer/parser/events/connection_open_confirm.go
+++ b/pkg/indexer/parser/events/connection_open_confirm.go
@@ -12,28 +12,29 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleConnectionOpenConfirm(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleConnectionOpenConfirm(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	action := decoder.StringFromMap(events[*idx].Data, "action")
+	event, _ := c.Peek()
+	action := decoder.StringFromMap(event.Data, "action")
 	isValidMsg := action == "/ibc.core.connection.v1.MsgConnectionOpenConfirm" || action == "/ibc.core.connection.v1.MsgConnectionOpenAck"
 	if !isValidMsg {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processConnectionOpenConfirm(ctx, events, msg, idx)
+	c.Next()
+	return processConnectionOpenConfirm(ctx, c, msg)
 }
 
-func processConnectionOpenConfirm(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	for i := *idx; i < len(events); i++ {
-		if events[i].Type != storageTypes.EventTypeConnectionOpenConfirm && events[i].Type != storageTypes.EventTypeConnectionOpenAck {
+func processConnectionOpenConfirm(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	for _, event := range c.Remaining() {
+		if event.Type != storageTypes.EventTypeConnectionOpenConfirm && event.Type != storageTypes.EventTypeConnectionOpenAck {
 			continue
 		}
-		cc := decode.NewConnectionOpen(events[i].Data)
+		cc := decode.NewConnectionOpen(event.Data)
 
 		conn := &storage.IbcConnection{
 			ConnectionHeight:         msg.Height,
@@ -54,6 +55,6 @@ func processConnectionOpenConfirm(ctx *context.Context, events []storage.Event, 
 		break
 	}
 
-	*idx += 2
+	c.Skip(2)
 	return nil
 }

--- a/pkg/indexer/parser/events/connection_open_init.go
+++ b/pkg/indexer/parser/events/connection_open_init.go
@@ -12,29 +12,30 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleConnectionOpenInit(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleConnectionOpenInit(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	action := decoder.StringFromMap(events[*idx].Data, "action")
+	event, _ := c.Peek()
+	action := decoder.StringFromMap(event.Data, "action")
 	isValidMsg := action == "/ibc.core.connection.v1.MsgConnectionOpenInit" || action == "/ibc.core.connection.v1.MsgConnectionOpenTry"
 
 	if !isValidMsg {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processConnectionOpenInit(ctx, events, msg, idx)
+	c.Next()
+	return processConnectionOpenInit(ctx, c, msg)
 }
 
-func processConnectionOpenInit(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	for i := *idx; i < len(events); i++ {
-		if events[i].Type != storageTypes.EventTypeConnectionOpenInit && events[i].Type != storageTypes.EventTypeConnectionOpenTry {
+func processConnectionOpenInit(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	for _, event := range c.Remaining() {
+		if event.Type != storageTypes.EventTypeConnectionOpenInit && event.Type != storageTypes.EventTypeConnectionOpenTry {
 			continue
 		}
-		cc := decode.NewConnectionOpen(events[i].Data)
+		cc := decode.NewConnectionOpen(event.Data)
 
 		conn := &storage.IbcConnection{
 			Height:                   msg.Height,
@@ -50,6 +51,6 @@ func processConnectionOpenInit(ctx *context.Context, events []storage.Event, msg
 		break
 	}
 
-	*idx += 2
+	c.Skip(2)
 	return nil
 }

--- a/pkg/indexer/parser/events/connection_open_init_test.go
+++ b/pkg/indexer/parser/events/connection_open_init_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +18,7 @@ func Test_handleConnectionOpenInit(t *testing.T) {
 		ctx    *context.Context
 		events []storage.Event
 		msg    []*storage.Message
-		idx    *int
+		idx    int
 	}{
 		{
 			name: "test 1",
@@ -79,13 +78,15 @@ func Test_handleConnectionOpenInit(t *testing.T) {
 					Height: 1036866,
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for i := range tt.msg {
-				err := handleConnectionOpenInit(tt.ctx, tt.events, tt.msg[i], tt.idx)
+				c := NewCursor(tt.events)
+				c.Skip(tt.idx)
+				err := handleConnectionOpenInit(tt.ctx, c, tt.msg[i])
 				require.NoError(t, err)
 				require.NotEmpty(t, tt.ctx.IbcConnections.Len())
 			}

--- a/pkg/indexer/parser/events/create_client.go
+++ b/pkg/indexer/parser/events/create_client.go
@@ -11,25 +11,27 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleCreateClient(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleCreateClient(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/ibc.core.client.v1.MsgCreateClient" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/ibc.core.client.v1.MsgCreateClient" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processCreateClient(ctx, events, msg, idx)
+	c.Next()
+	return processCreateClient(ctx, c, msg)
 }
 
-func processCreateClient(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if len(events) <= *idx {
+func processCreateClient(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	event, ok := c.Peek()
+	if !ok {
 		return errors.New("not enough events for create client")
 	}
-	cc, err := decode.NewUpdateClient(events[*idx].Data)
+	cc, err := decode.NewUpdateClient(event.Data)
 	if err != nil {
 		return errors.Wrap(err, "parsing CreateClient event")
 	}
@@ -63,6 +65,6 @@ func processCreateClient(ctx *context.Context, events []storage.Event, msg *stor
 		TxId: msg.TxId,
 	}
 	ctx.AddIbcClient(ibcClient)
-	*idx += 2
+	c.Skip(2)
 	return nil
 }

--- a/pkg/indexer/parser/events/create_collateral_token.go
+++ b/pkg/indexer/parser/events/create_collateral_token.go
@@ -13,75 +13,73 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleCreateCollateralToken(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleCreateCollateralToken(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/hyperlane.warp.v1.MsgCreateCollateralToken" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/hyperlane.warp.v1.MsgCreateCollateralToken" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processCreateCollateralToken(ctx, events, msg, idx)
+	c.Next()
+	return processCreateCollateralToken(ctx, c, msg)
 }
 
-func processCreateCollateralToken(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	end := false
-	for !end {
-		if events[*idx].Type == types.EventTypeHyperlanewarpv1EventCreateCollateralToken {
-			createToken, err := decode.NewCreateCollateralToken(events[*idx].Data)
-			if err != nil {
-				return errors.Wrap(err, "parsing create collateral token event")
-			}
-
-			originMailboxId, err := util.DecodeHexAddress(createToken.MailboxId)
-			if err != nil {
-				return errors.Wrap(err, "decode mailbox id")
-			}
-
-			tokenId, err := util.DecodeHexAddress(createToken.TokenId)
-			if err != nil {
-				return errors.Wrap(err, "decode token id")
-			}
-
-			token := &storage.HLToken{
-				Height: ctx.Block.Height,
-				Time:   ctx.Block.Time,
-				Denom:  createToken.Denom,
-				Type:   types.HLTokenTypeCollateral,
-				Mailbox: &storage.HLMailbox{
-					Height:     ctx.Block.Height,
-					Time:       ctx.Block.Time,
-					Mailbox:    originMailboxId.Bytes(),
-					InternalId: originMailboxId.GetInternalId(),
-				},
-				TokenId:  tokenId.Bytes(),
-				Received: types.NumericZero(),
-				Sent:     types.NumericZero(),
-				TxId:     msg.TxId,
-			}
-
-			if createToken.Owner != "" {
-				token.Owner = &storage.Address{
-					Address:    createToken.Owner,
-					Height:     msg.Height,
-					LastHeight: msg.Height,
-					Balances:   []storage.Balance{storage.EmptyBalance()},
-				}
-				if err := ctx.AddAddress(token.Owner); err != nil {
-					return errors.Wrap(err, "add address")
-				}
-			}
-
-			ctx.AddHlToken(token)
-			end = true
+func processCreateCollateralToken(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	for event := range c.MsgEvents("action") {
+		if event.Type != types.EventTypeHyperlanewarpv1EventCreateCollateralToken {
+			continue
 		}
 
-		action := decoder.StringFromMap(events[*idx].Data, "action")
-		end = len(events)-1 == *idx || action != "" || end
-		*idx += 1
+		createToken, err := decode.NewCreateCollateralToken(event.Data)
+		if err != nil {
+			return errors.Wrap(err, "parsing create collateral token event")
+		}
+
+		originMailboxId, err := util.DecodeHexAddress(createToken.MailboxId)
+		if err != nil {
+			return errors.Wrap(err, "decode mailbox id")
+		}
+
+		tokenId, err := util.DecodeHexAddress(createToken.TokenId)
+		if err != nil {
+			return errors.Wrap(err, "decode token id")
+		}
+
+		token := &storage.HLToken{
+			Height: ctx.Block.Height,
+			Time:   ctx.Block.Time,
+			Denom:  createToken.Denom,
+			Type:   types.HLTokenTypeCollateral,
+			Mailbox: &storage.HLMailbox{
+				Height:     ctx.Block.Height,
+				Time:       ctx.Block.Time,
+				Mailbox:    originMailboxId.Bytes(),
+				InternalId: originMailboxId.GetInternalId(),
+			},
+			TokenId:  tokenId.Bytes(),
+			Received: types.NumericZero(),
+			Sent:     types.NumericZero(),
+			TxId:     msg.TxId,
+		}
+
+		if createToken.Owner != "" {
+			token.Owner = &storage.Address{
+				Address:    createToken.Owner,
+				Height:     msg.Height,
+				LastHeight: msg.Height,
+				Balances:   []storage.Balance{storage.EmptyBalance()},
+			}
+			if err := ctx.AddAddress(token.Owner); err != nil {
+				return errors.Wrap(err, "add address")
+			}
+		}
+
+		ctx.AddHlToken(token)
+		break
 	}
 	return nil
 }

--- a/pkg/indexer/parser/events/create_collateral_token_test.go
+++ b/pkg/indexer/parser/events/create_collateral_token_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -21,8 +20,9 @@ func Test_handleCreateCollateralToken(t *testing.T) {
 		ctx    *context.Context
 		events []storage.Event
 		msg    *storage.Message
-		idx    *int
-		token  *storage.HLToken
+		idx    int
+
+		token *storage.HLToken
 	}{
 		{
 			name: "test 1",
@@ -61,7 +61,8 @@ func Test_handleCreateCollateralToken(t *testing.T) {
 					"Owner":         "celestia1zvdlcmplx4gdh4hajwlsegnn2xzzfy470gjw4c",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			token: &storage.HLToken{
 				Height:           1036866,
 				Time:             ts,
@@ -94,7 +95,9 @@ func Test_handleCreateCollateralToken(t *testing.T) {
 				Height: 1036866,
 				Time:   ts,
 			}
-			err := handleCreateCollateralToken(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			c.Skip(tt.idx)
+			err := handleCreateCollateralToken(tt.ctx, c, tt.msg)
 			require.NoError(t, err)
 			require.NotEmpty(t, tt.ctx.HlTokens.Len())
 

--- a/pkg/indexer/parser/events/create_mailbox.go
+++ b/pkg/indexer/parser/events/create_mailbox.go
@@ -15,73 +15,71 @@ import (
 
 const null = "null"
 
-func handleCreateMailbox(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleCreateMailbox(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/hyperlane.core.v1.MsgCreateMailbox" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/hyperlane.core.v1.MsgCreateMailbox" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processCreateMailbox(ctx, events, msg, idx)
+	c.Next()
+	return processCreateMailbox(ctx, c, msg)
 }
 
-func processCreateMailbox(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	end := false
-	for !end {
-		if events[*idx].Type == types.EventTypeHyperlanecorev1EventCreateMailbox {
-			createMailbox, err := decode.NewCreateMailbox(events[*idx].Data)
-			if err != nil {
-				return errors.Wrap(err, "parsing create mailbox event")
-			}
-			mailboxId, err := util.DecodeHexAddress(createMailbox.MailboxId)
-			if err != nil {
-				return errors.Wrapf(err, "decode mailbox id: %s", createMailbox.MailboxId)
-			}
-			defaultIsm, err := util.DecodeHexAddress(createMailbox.DefaultIsm)
-			if err != nil {
-				return errors.Wrapf(err, "decode default ISM: %s", createMailbox.DefaultIsm)
-			}
-
-			mailbox := &storage.HLMailbox{
-				Height:     ctx.Block.Height,
-				Time:       ctx.Block.Time,
-				Mailbox:    mailboxId.Bytes(),
-				InternalId: mailboxId.GetInternalId(),
-				Owner: &storage.Address{
-					Address: createMailbox.Owner,
-				},
-				DefaultIsm: defaultIsm.Bytes(),
-				Domain:     createMailbox.LocalDomain,
-				TxId:       msg.TxId,
-			}
-
-			if len(createMailbox.DefaultHook) > 0 && createMailbox.DefaultHook != null {
-				defaultHook, err := util.DecodeHexAddress(createMailbox.DefaultHook)
-				if err != nil {
-					return errors.Wrapf(err, "decode default hook: %s", createMailbox.DefaultHook)
-				}
-				mailbox.DefaultHook = defaultHook.Bytes()
-			}
-
-			if len(createMailbox.RequiredHook) > 0 && createMailbox.RequiredHook != null {
-				requiredHook, err := util.DecodeHexAddress(createMailbox.RequiredHook)
-				if err != nil {
-					return errors.Wrapf(err, "decode required hook: %s", createMailbox.RequiredHook)
-				}
-				mailbox.DefaultHook = requiredHook.Bytes()
-			}
-
-			ctx.AddHlMailbox(mailbox)
-			end = true
+func processCreateMailbox(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	for event := range c.MsgEvents("action") {
+		if event.Type != types.EventTypeHyperlanecorev1EventCreateMailbox {
+			continue
 		}
 
-		action := decoder.StringFromMap(events[*idx].Data, "action")
-		end = len(events)-1 == *idx || action != "" || end
-		*idx += 1
+		createMailbox, err := decode.NewCreateMailbox(event.Data)
+		if err != nil {
+			return errors.Wrap(err, "parsing create mailbox event")
+		}
+		mailboxId, err := util.DecodeHexAddress(createMailbox.MailboxId)
+		if err != nil {
+			return errors.Wrapf(err, "decode mailbox id: %s", createMailbox.MailboxId)
+		}
+		defaultIsm, err := util.DecodeHexAddress(createMailbox.DefaultIsm)
+		if err != nil {
+			return errors.Wrapf(err, "decode default ISM: %s", createMailbox.DefaultIsm)
+		}
+
+		mailbox := &storage.HLMailbox{
+			Height:     ctx.Block.Height,
+			Time:       ctx.Block.Time,
+			Mailbox:    mailboxId.Bytes(),
+			InternalId: mailboxId.GetInternalId(),
+			Owner: &storage.Address{
+				Address: createMailbox.Owner,
+			},
+			DefaultIsm: defaultIsm.Bytes(),
+			Domain:     createMailbox.LocalDomain,
+			TxId:       msg.TxId,
+		}
+
+		if len(createMailbox.DefaultHook) > 0 && createMailbox.DefaultHook != null {
+			defaultHook, err := util.DecodeHexAddress(createMailbox.DefaultHook)
+			if err != nil {
+				return errors.Wrapf(err, "decode default hook: %s", createMailbox.DefaultHook)
+			}
+			mailbox.DefaultHook = defaultHook.Bytes()
+		}
+
+		if len(createMailbox.RequiredHook) > 0 && createMailbox.RequiredHook != null {
+			requiredHook, err := util.DecodeHexAddress(createMailbox.RequiredHook)
+			if err != nil {
+				return errors.Wrapf(err, "decode required hook: %s", createMailbox.RequiredHook)
+			}
+			mailbox.DefaultHook = requiredHook.Bytes()
+		}
+
+		ctx.AddHlMailbox(mailbox)
+		break
 	}
 	return nil
 }

--- a/pkg/indexer/parser/events/create_mailbox_test.go
+++ b/pkg/indexer/parser/events/create_mailbox_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -20,7 +19,7 @@ func Test_handleCreateMailbox(t *testing.T) {
 		ctx    *context.Context
 		events []storage.Event
 		msg    []*storage.Message
-		idx    *int
+		idx    int
 	}{
 		{
 			name: "test 1",
@@ -51,7 +50,7 @@ func Test_handleCreateMailbox(t *testing.T) {
 					Height: 1036866,
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		}, {
 			name: "test 2",
 			ctx:  context.NewContext(),
@@ -85,7 +84,7 @@ func Test_handleCreateMailbox(t *testing.T) {
 					Height: 1036866,
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		},
 	}
 	for _, tt := range tests {
@@ -95,7 +94,9 @@ func Test_handleCreateMailbox(t *testing.T) {
 				Time:   time.Now(),
 			}
 			for i := range tt.msg {
-				err := handleCreateMailbox(tt.ctx, tt.events, tt.msg[i], tt.idx)
+				c := NewCursor(tt.events)
+				c.Skip(tt.idx)
+				err := handleCreateMailbox(tt.ctx, c, tt.msg[i])
 				require.NoError(t, err)
 				require.NotEmpty(t, tt.ctx.HlMailboxes.Len())
 			}

--- a/pkg/indexer/parser/events/create_synthetic_token.go
+++ b/pkg/indexer/parser/events/create_synthetic_token.go
@@ -13,75 +13,73 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleCreateSyntheticToken(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleCreateSyntheticToken(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/hyperlane.warp.v1.MsgCreateSyntheticToken" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/hyperlane.warp.v1.MsgCreateSyntheticToken" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processCreateSyntheticToken(ctx, events, msg, idx)
+	c.Next()
+	return processCreateSyntheticToken(ctx, c, msg)
 }
 
-func processCreateSyntheticToken(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	end := false
-	for !end {
-		if events[*idx].Type == types.EventTypeHyperlanewarpv1EventCreateSyntheticToken {
-			createToken, err := decode.NewCreateSyntheticToken(events[*idx].Data)
-			if err != nil {
-				return errors.Wrap(err, "parsing create synthetic token event")
-			}
-
-			originMailboxId, err := util.DecodeHexAddress(createToken.MailboxId)
-			if err != nil {
-				return errors.Wrap(err, "decode mailbox id")
-			}
-
-			tokenId, err := util.DecodeHexAddress(createToken.TokenId)
-			if err != nil {
-				return errors.Wrap(err, "decode token id")
-			}
-
-			token := &storage.HLToken{
-				Height: ctx.Block.Height,
-				Time:   ctx.Block.Time,
-				Denom:  createToken.Denom,
-				Type:   types.HLTokenTypeSynthetic,
-				Mailbox: &storage.HLMailbox{
-					Height:     ctx.Block.Height,
-					Time:       ctx.Block.Time,
-					Mailbox:    originMailboxId.Bytes(),
-					InternalId: originMailboxId.GetInternalId(),
-				},
-				TokenId:  tokenId.Bytes(),
-				Sent:     types.NumericZero(),
-				Received: types.NumericZero(),
-				TxId:     msg.TxId,
-			}
-
-			if createToken.Owner != "" {
-				token.Owner = &storage.Address{
-					Address:    createToken.Owner,
-					Height:     msg.Height,
-					LastHeight: msg.Height,
-					Balances:   []storage.Balance{storage.EmptyBalance()},
-				}
-				if err := ctx.AddAddress(token.Owner); err != nil {
-					return errors.Wrap(err, "add address")
-				}
-			}
-
-			ctx.AddHlToken(token)
-			end = true
+func processCreateSyntheticToken(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	for event := range c.MsgEvents("action") {
+		if event.Type != types.EventTypeHyperlanewarpv1EventCreateSyntheticToken {
+			continue
 		}
 
-		action := decoder.StringFromMap(events[*idx].Data, "action")
-		end = len(events)-1 == *idx || action != "" || end
-		*idx += 1
+		createToken, err := decode.NewCreateSyntheticToken(event.Data)
+		if err != nil {
+			return errors.Wrap(err, "parsing create synthetic token event")
+		}
+
+		originMailboxId, err := util.DecodeHexAddress(createToken.MailboxId)
+		if err != nil {
+			return errors.Wrap(err, "decode mailbox id")
+		}
+
+		tokenId, err := util.DecodeHexAddress(createToken.TokenId)
+		if err != nil {
+			return errors.Wrap(err, "decode token id")
+		}
+
+		token := &storage.HLToken{
+			Height: ctx.Block.Height,
+			Time:   ctx.Block.Time,
+			Denom:  createToken.Denom,
+			Type:   types.HLTokenTypeSynthetic,
+			Mailbox: &storage.HLMailbox{
+				Height:     ctx.Block.Height,
+				Time:       ctx.Block.Time,
+				Mailbox:    originMailboxId.Bytes(),
+				InternalId: originMailboxId.GetInternalId(),
+			},
+			TokenId:  tokenId.Bytes(),
+			Sent:     types.NumericZero(),
+			Received: types.NumericZero(),
+			TxId:     msg.TxId,
+		}
+
+		if createToken.Owner != "" {
+			token.Owner = &storage.Address{
+				Address:    createToken.Owner,
+				Height:     msg.Height,
+				LastHeight: msg.Height,
+				Balances:   []storage.Balance{storage.EmptyBalance()},
+			}
+			if err := ctx.AddAddress(token.Owner); err != nil {
+				return errors.Wrap(err, "add address")
+			}
+		}
+
+		ctx.AddHlToken(token)
+		break
 	}
 	return nil
 }

--- a/pkg/indexer/parser/events/create_synthetic_token_test.go
+++ b/pkg/indexer/parser/events/create_synthetic_token_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -22,8 +21,9 @@ func Test_handleCreateSyntheticToken(t *testing.T) {
 		ctx    *context.Context
 		events []storage.Event
 		msg    *storage.Message
-		idx    *int
-		token  *storage.HLToken
+		idx    int
+
+		token *storage.HLToken
 	}{
 		{
 			name: "test 1",
@@ -59,7 +59,8 @@ func Test_handleCreateSyntheticToken(t *testing.T) {
 					"Owner":         "celestia1zvdlcmplx4gdh4hajwlsegnn2xzzfy470gjw4c",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			token: &storage.HLToken{
 				Height:           1036866,
 				Time:             ts,
@@ -92,7 +93,9 @@ func Test_handleCreateSyntheticToken(t *testing.T) {
 				Height: 1036866,
 				Time:   ts,
 			}
-			err := handleCreateSyntheticToken(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			c.Skip(tt.idx)
+			err := handleCreateSyntheticToken(tt.ctx, c, tt.msg)
 			require.NoError(t, err)
 			require.NotEmpty(t, tt.ctx.HlTokens.Len())
 

--- a/pkg/indexer/parser/events/critical_boundary_test.go
+++ b/pkg/indexer/parser/events/critical_boundary_test.go
@@ -10,14 +10,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Test_toTheNextAction_criticalBoundary tests the critical case where increment happens
-// at exactly len(events)-2, and after increment we're at len(events)-1
+// Test_toTheNextAction_criticalBoundary tests the critical case where the
+// cursor sits at or near the last event when SkipToNext("action") is called
+// (this used to test the standalone toTheNextAction helper, which
+// Cursor.SkipToNext replaced — Peek/Next make out-of-bounds access
+// impossible by construction, so these cases can no longer panic).
 func Test_toTheNextAction_criticalBoundary(t *testing.T) {
 	tests := []struct {
-		name        string
-		events      []storage.Event
-		startIdx    int
-		expectPanic bool
+		name     string
+		events   []storage.Event
+		startIdx int
 	}{
 		{
 			name: "CRITICAL: increment at len-2 with empty action",
@@ -35,8 +37,7 @@ func Test_toTheNextAction_criticalBoundary(t *testing.T) {
 					},
 				},
 			},
-			startIdx:    0,
-			expectPanic: false, // should NOT panic if bounds check is correct
+			startIdx: 0,
 		},
 		{
 			name: "CRITICAL: three elements, start at len-2",
@@ -60,8 +61,7 @@ func Test_toTheNextAction_criticalBoundary(t *testing.T) {
 					},
 				},
 			},
-			startIdx:    1,     // start at len-2
-			expectPanic: false, // should NOT panic
+			startIdx: 1, // start at len-2
 		},
 		{
 			name: "Edge case: two elements both empty",
@@ -79,172 +79,18 @@ func Test_toTheNextAction_criticalBoundary(t *testing.T) {
 					},
 				},
 			},
-			startIdx:    0,
-			expectPanic: false,
+			startIdx: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			idx := tt.startIdx
+			c := NewCursor(tt.events)
+			c.Skip(tt.startIdx)
 
-			if tt.expectPanic {
-				require.Panics(t, func() {
-					toTheNextAction(tt.events, &idx)
-				}, "Expected panic but function completed normally")
-			} else {
-				require.NotPanics(t, func() {
-					toTheNextAction(tt.events, &idx)
-				}, "Function should not panic with proper boundary checks")
-			}
-
-			// Additional safety check: index should never exceed len(events)-1
-			require.LessOrEqual(t, idx, len(tt.events)-1,
-				"Index should never exceed last valid position")
-		})
-	}
-}
-
-// Test_acknowledgement_criticalLoop tests the loop in acknowledgement handler
-// This is the exact scenario from line 81-98 in acknowledgement.go
-func Test_acknowledgement_criticalLoop(t *testing.T) {
-	tests := []struct {
-		name        string
-		events      []storage.Event
-		startIdx    int
-		expectPanic bool
-	}{
-		{
-			name: "Loop with increment reaching exact boundary",
-			events: []storage.Event{
-				{
-					Type: "some_event",
-					Data: map[string]string{
-						"action": "",
-					},
-				},
-				{
-					Type: "last_event",
-					Data: map[string]string{
-						"action": "",
-					},
-				},
-			},
-			startIdx:    0,
-			expectPanic: false,
-		},
-		{
-			name: "Multiple events with empty actions",
-			events: []storage.Event{
-				{
-					Type: "event1",
-					Data: map[string]string{
-						"action": "",
-					},
-				},
-				{
-					Type: "event2",
-					Data: map[string]string{
-						"action": "",
-					},
-				},
-				{
-					Type: "event3",
-					Data: map[string]string{
-						"action": "",
-					},
-				},
-			},
-			startIdx:    0,
-			expectPanic: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			idx := tt.startIdx
-
-			// Simulate the loop from acknowledgement.go:81-98
-			simulateLoop := func() {
-				action := ""
-				for action == "" && len(tt.events)-1 > idx {
-					idx += 1
-					// This line could panic if bounds check is wrong:
-					action = tt.events[idx].Data["action"]
-				}
-			}
-
-			if tt.expectPanic {
-				require.Panics(t, simulateLoop)
-			} else {
-				require.NotPanics(t, simulateLoop)
-			}
-		})
-	}
-}
-
-// Test_recvPacket_criticalLoop tests the loop in recv_packet handler
-// This is the exact scenario from line 104-116 in recv_packet.go
-func Test_recvPacket_criticalLoop(t *testing.T) {
-	tests := []struct {
-		name        string
-		events      []storage.Event
-		startIdx    int
-		expectPanic bool
-	}{
-		{
-			name: "Loop reaching exact end",
-			events: []storage.Event{
-				{
-					Type: "event1",
-					Data: map[string]string{
-						"action": "",
-					},
-				},
-				{
-					Type: "event2",
-					Data: map[string]string{
-						"action": "",
-					},
-				},
-			},
-			startIdx:    0,
-			expectPanic: false,
-		},
-		{
-			name: "Single event with empty action",
-			events: []storage.Event{
-				{
-					Type: "event",
-					Data: map[string]string{
-						"action": "",
-					},
-				},
-			},
-			startIdx:    0,
-			expectPanic: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			idx := tt.startIdx
-
-			// Simulate the loop from recv_packet.go:104-116
-			simulateLoop := func() {
-				action := ""
-				for action == "" && len(tt.events)-1 > idx {
-					idx += 1
-					// This line could cause panic if idx is out of bounds
-					action = tt.events[idx].Data["action"]
-				}
-			}
-
-			if tt.expectPanic {
-				require.Panics(t, simulateLoop)
-			} else {
-				require.NotPanics(t, simulateLoop)
-			}
+			require.NotPanics(t, func() {
+				c.SkipToNext("action")
+			}, "Function should not panic with proper boundary checks")
 		})
 	}
 }

--- a/pkg/indexer/parser/events/cursor.go
+++ b/pkg/indexer/parser/events/cursor.go
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2025 Bb Strategy Pte. Ltd. <celenium@baking-bad.org>
+// SPDX-License-Identifier: MIT
+
+package events
+
+import (
+	"iter"
+
+	"github.com/celenium-io/celestia-indexer/internal/storage"
+	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/decoder"
+)
+
+// Cursor walks a transaction's events, shared across all of that
+// transaction's messages. It owns the boundary logic: an event whose Data
+// carries a non-empty value for a "stop key" ("action" for top-level
+// messages, "module" for IBC-nested ones) marks the start of the next
+// message and is never consumed on behalf of the current one.
+//
+// A Cursor is not safe for concurrent use.
+type Cursor struct {
+	events []storage.Event
+	pos    int
+}
+
+// NewCursor returns a Cursor positioned at the first event of events.
+func NewCursor(events []storage.Event) *Cursor {
+	return &Cursor{
+		events: events,
+		pos:    0,
+	}
+}
+
+// Peek reports the event at the current position without consuming it.
+// The second result is false once the cursor has reached the end, in
+// which case the first result is the zero storage.Event.
+func (c *Cursor) Peek() (storage.Event, bool) {
+	if c.pos >= len(c.events) {
+		return storage.Event{}, false
+	}
+	return c.events[c.pos], true
+}
+
+// Next consumes and returns the event at the current position, advancing
+// the cursor by one. The second result is false once the cursor has
+// reached the end, in which case the position is left unchanged and the
+// first result is the zero storage.Event.
+func (c *Cursor) Next() (storage.Event, bool) {
+	if c.pos >= len(c.events) {
+		return storage.Event{}, false
+	}
+	event := c.events[c.pos]
+	c.pos++
+	return event, true
+}
+
+// MsgEvents yields events starting at the current position, up to
+// (exclusive) the next event whose Data carries a non-empty value for
+// stopKey, consuming each event as it is yielded. The boundary event
+// itself is never consumed.
+//
+// If the event at the current position already carries stopKey,
+// MsgEvents yields nothing and leaves the position unchanged — call it
+// again only after advancing past the boundary (e.g. via Next or
+// SkipToNext), otherwise it is a no-op.
+func (c *Cursor) MsgEvents(stopKey string) iter.Seq[storage.Event] {
+	return func(yield func(storage.Event) bool) {
+		for c.pos < len(c.events) {
+			if decoder.StringFromMap(c.events[c.pos].Data, stopKey) != "" {
+				return
+			}
+			event := c.events[c.pos]
+			c.pos++
+			if !yield(event) {
+				return
+			}
+		}
+	}
+}
+
+// SkipToNext positions the cursor at the next event whose Data carries a
+// non-empty value for stopKey (or at the end, if none remains), without
+// consuming that event or reporting any of the skipped ones. It is a
+// no-op if the event at the current position already carries stopKey.
+func (c *Cursor) SkipToNext(stopKey string) {
+	for range c.MsgEvents(stopKey) {
+	}
+}
+
+// Skip advances the cursor by n events without inspecting or reporting
+// them, for handlers that unconditionally jump a fixed number of events.
+// n must be non-negative. If fewer than n events remain, the cursor is
+// left at the end.
+func (c *Cursor) Skip(n int) {
+	c.pos += n
+	if c.pos > len(c.events) {
+		c.pos = len(c.events)
+	}
+}
+
+// Remaining returns the events from the current position to the end,
+// without consuming them. It is meant for read-only lookahead (searching
+// for an event further ahead while leaving the position where a
+// subsequent, separately-computed Skip expects it to be) — prefer Next,
+// MsgEvents, or SkipToNext wherever the scan itself should advance the
+// cursor.
+func (c *Cursor) Remaining() []storage.Event {
+	return c.events[c.pos:]
+}

--- a/pkg/indexer/parser/events/cursor_test.go
+++ b/pkg/indexer/parser/events/cursor_test.go
@@ -1,0 +1,312 @@
+// SPDX-FileCopyrightText: 2025 Bb Strategy Pte. Ltd. <celenium@baking-bad.org>
+// SPDX-License-Identifier: MIT
+
+package events
+
+import (
+	"testing"
+
+	"github.com/celenium-io/celestia-indexer/internal/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// event returns a storage.Event carrying data[stopKey] = value, or no
+// stopKey data at all when stopKey is empty. label is stashed under
+// "label" purely so test failures can identify which event was involved.
+func event(label string, stopKey, value string) storage.Event {
+	data := map[string]string{"label": label}
+	if stopKey != "" {
+		data[stopKey] = value
+	}
+	return storage.Event{Data: data}
+}
+
+func labels(events []storage.Event) []string {
+	out := make([]string, len(events))
+	for i, e := range events {
+		out[i] = e.Data["label"]
+	}
+	return out
+}
+
+func collect(seq func(yield func(storage.Event) bool)) []storage.Event {
+	var out []storage.Event
+	for e := range seq {
+		out = append(out, e)
+	}
+	return out
+}
+
+func TestCursor_PeekNext_EmptySlice(t *testing.T) {
+	c := NewCursor(nil)
+
+	_, ok := c.Peek()
+	require.False(t, ok)
+
+	_, ok = c.Next()
+	require.False(t, ok)
+}
+
+func TestCursor_Peek_DoesNotAdvance(t *testing.T) {
+	c := NewCursor([]storage.Event{
+		event("a", "", ""),
+		event("b", "", ""),
+	})
+
+	first, ok := c.Peek()
+	require.True(t, ok)
+	require.Equal(t, "a", first.Data["label"])
+
+	// Peeking again must return the same event.
+	again, ok := c.Peek()
+	require.True(t, ok)
+	require.Equal(t, "a", again.Data["label"])
+
+	next, ok := c.Next()
+	require.True(t, ok)
+	require.Equal(t, "a", next.Data["label"])
+
+	second, ok := c.Peek()
+	require.True(t, ok)
+	require.Equal(t, "b", second.Data["label"])
+}
+
+func TestCursor_Next_ExhaustsThenReportsFalse(t *testing.T) {
+	c := NewCursor([]storage.Event{
+		event("a", "", ""),
+		event("b", "", ""),
+	})
+
+	first, ok := c.Next()
+	require.True(t, ok)
+	require.Equal(t, "a", first.Data["label"])
+
+	second, ok := c.Next()
+	require.True(t, ok)
+	require.Equal(t, "b", second.Data["label"])
+
+	// Once exhausted, both Next and Peek keep reporting false without
+	// panicking, and the position does not run past the end.
+	_, ok = c.Next()
+	require.False(t, ok)
+	_, ok = c.Peek()
+	require.False(t, ok)
+	_, ok = c.Next()
+	require.False(t, ok)
+}
+
+func TestCursor_MsgEvents_StopsBeforeBoundaryWithoutConsumingIt(t *testing.T) {
+	c := NewCursor([]storage.Event{
+		event("a", "", ""),
+		event("b", "", ""),
+		event("boundary", "action", "/some.Msg"),
+		event("d", "", ""),
+	})
+
+	got := collect(c.MsgEvents("action"))
+	require.Equal(t, []string{"a", "b"}, labels(got))
+
+	// The boundary event must still be there, unconsumed.
+	next, ok := c.Peek()
+	require.True(t, ok)
+	require.Equal(t, "boundary", next.Data["label"])
+}
+
+func TestCursor_MsgEvents_NoBoundary_YieldsEverythingAndEndsAtEOF(t *testing.T) {
+	c := NewCursor([]storage.Event{
+		event("a", "", ""),
+		event("b", "", ""),
+		event("c", "", ""),
+	})
+
+	got := collect(c.MsgEvents("action"))
+	require.Equal(t, []string{"a", "b", "c"}, labels(got))
+
+	_, ok := c.Peek()
+	require.False(t, ok, "cursor must be at the end when no boundary event exists")
+}
+
+func TestCursor_MsgEvents_EmptySlice_YieldsNothing(t *testing.T) {
+	c := NewCursor(nil)
+
+	got := collect(c.MsgEvents("action"))
+	require.Empty(t, got)
+}
+
+func TestCursor_MsgEvents_NoOpWhenAlreadyAtBoundary(t *testing.T) {
+	c := NewCursor([]storage.Event{
+		event("boundary", "action", "/some.Msg"),
+		event("a", "", ""),
+	})
+
+	got := collect(c.MsgEvents("action"))
+	require.Empty(t, got, "MsgEvents must yield nothing when the current event is itself a boundary")
+
+	next, ok := c.Peek()
+	require.True(t, ok)
+	require.Equal(t, "boundary", next.Data["label"], "position must be unchanged")
+}
+
+func TestCursor_MsgEvents_EarlyBreakLeavesRemainingEventsUnconsumed(t *testing.T) {
+	c := NewCursor([]storage.Event{
+		event("a", "", ""),
+		event("b", "", ""),
+		event("boundary", "action", "/some.Msg"),
+	})
+
+	var got []storage.Event
+	for e := range c.MsgEvents("action") {
+		got = append(got, e)
+		if len(got) == 1 {
+			break
+		}
+	}
+	require.Equal(t, []string{"a"}, labels(got))
+
+	// "b" was not consumed by the aborted iteration.
+	next, ok := c.Peek()
+	require.True(t, ok)
+	require.Equal(t, "b", next.Data["label"])
+}
+
+func TestCursor_SkipToNext_LandsOnBoundaryWithoutConsumingIt(t *testing.T) {
+	c := NewCursor([]storage.Event{
+		event("a", "", ""),
+		event("b", "", ""),
+		event("boundary", "module", "staking"),
+		event("d", "", ""),
+	})
+
+	c.SkipToNext("module")
+
+	next, ok := c.Peek()
+	require.True(t, ok)
+	require.Equal(t, "boundary", next.Data["label"])
+
+	// The boundary event is still there to be consumed by the caller.
+	consumed, ok := c.Next()
+	require.True(t, ok)
+	require.Equal(t, "boundary", consumed.Data["label"])
+}
+
+func TestCursor_SkipToNext_NoBoundary_EndsAtEOF(t *testing.T) {
+	c := NewCursor([]storage.Event{
+		event("a", "", ""),
+		event("b", "", ""),
+	})
+
+	c.SkipToNext("action")
+
+	_, ok := c.Peek()
+	require.False(t, ok)
+}
+
+func TestCursor_SkipToNext_NoOpWhenAlreadyAtBoundary(t *testing.T) {
+	c := NewCursor([]storage.Event{
+		event("boundary", "action", "/some.Msg"),
+		event("a", "", ""),
+	})
+
+	c.SkipToNext("action")
+
+	next, ok := c.Peek()
+	require.True(t, ok)
+	require.Equal(t, "boundary", next.Data["label"], "position must not move past an already-current boundary")
+}
+
+func TestCursor_SkipToNext_EmptySlice_NoOp(t *testing.T) {
+	c := NewCursor(nil)
+
+	c.SkipToNext("action")
+
+	_, ok := c.Peek()
+	require.False(t, ok)
+}
+
+func TestCursor_DifferentStopKeysAreIndependent(t *testing.T) {
+	c := NewCursor([]storage.Event{
+		event("a", "module", "staking"), // carries "module" but not "action"
+		event("b", "", ""),
+		event("boundary", "action", "/some.Msg"),
+	})
+
+	// Asking for the "action" boundary must not stop early on an event
+	// that only carries "module".
+	got := collect(c.MsgEvents("action"))
+	require.Equal(t, []string{"a", "b"}, labels(got))
+}
+
+func TestCursor_Skip(t *testing.T) {
+	c := NewCursor([]storage.Event{
+		event("a", "", ""),
+		event("b", "", ""),
+		event("c", "", ""),
+	})
+
+	c.Skip(2)
+
+	next, ok := c.Peek()
+	require.True(t, ok)
+	require.Equal(t, "c", next.Data["label"])
+}
+
+func TestCursor_Skip_Zero_NoOp(t *testing.T) {
+	c := NewCursor([]storage.Event{
+		event("a", "", ""),
+	})
+
+	c.Skip(0)
+
+	next, ok := c.Peek()
+	require.True(t, ok)
+	require.Equal(t, "a", next.Data["label"])
+}
+
+func TestCursor_Skip_PastEnd_ClampsToEnd(t *testing.T) {
+	c := NewCursor([]storage.Event{
+		event("a", "", ""),
+		event("b", "", ""),
+	})
+
+	c.Skip(10)
+
+	_, ok := c.Peek()
+	require.False(t, ok)
+
+	// Clamped, not overflowed: a further Skip must not panic or move
+	// past the end.
+	require.NotPanics(t, func() { c.Skip(5) })
+	_, ok = c.Peek()
+	require.False(t, ok)
+}
+
+func TestCursor_Skip_EmptySlice_NoOp(t *testing.T) {
+	c := NewCursor(nil)
+
+	require.NotPanics(t, func() { c.Skip(3) })
+	_, ok := c.Peek()
+	require.False(t, ok)
+}
+
+func TestCursor_Remaining_DoesNotConsume(t *testing.T) {
+	c := NewCursor([]storage.Event{
+		event("a", "", ""),
+		event("b", "", ""),
+		event("c", "", ""),
+	})
+	c.Next()
+
+	require.Equal(t, []string{"b", "c"}, labels(c.Remaining()))
+
+	// Remaining must be read-only: position is unchanged by the call.
+	next, ok := c.Peek()
+	require.True(t, ok)
+	require.Equal(t, "b", next.Data["label"])
+}
+
+func TestCursor_Remaining_EmptyAtEnd(t *testing.T) {
+	c := NewCursor([]storage.Event{event("a", "", "")})
+	c.Next()
+
+	require.Empty(t, c.Remaining())
+}

--- a/pkg/indexer/parser/events/delegate.go
+++ b/pkg/indexer/parser/events/delegate.go
@@ -14,27 +14,29 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleDelegate(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleDelegate(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/cosmos.staking.v1beta1.MsgDelegate" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/cosmos.staking.v1beta1.MsgDelegate" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processDelegate(ctx, events, msg, idx)
+	c.Next()
+	return processDelegate(ctx, c, msg)
 }
 
-func processDelegate(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
+func processDelegate(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	first, _ := c.Peek()
 	var (
 		validator  = storage.EmptyValidator()
 		delegation = storage.Delegation{
 			Validator: &validator,
 		}
-		msgIdx    = decoder.StringFromMap(events[*idx].Data, "msg_index")
+		msgIdx    = decoder.StringFromMap(first.Data, "msg_index")
 		newFormat = msgIdx != ""
 
 		endDelegation = func(event storage.Event, key string) error {
@@ -71,22 +73,22 @@ func processDelegate(ctx *context.Context, events []storage.Event, msg *storage.
 		}
 	)
 
-	for i := *idx; i < len(events); i++ {
-		switch events[i].Type {
+	for {
+		event, ok := c.Next()
+		if !ok {
+			return nil
+		}
+		switch event.Type {
 		case storageTypes.EventTypeMessage:
-			if module := decoder.StringFromMap(events[i].Data, "module"); module == storageTypes.ModuleNameStaking.String() {
-				if err := endDelegation(events[i], "sender"); err != nil {
-					return errors.Wrap(err, "end delegation")
-				}
-				*idx = i + 1
-				return nil
+			if module := decoder.StringFromMap(event.Data, "module"); module == storageTypes.ModuleNameStaking.String() {
+				return errors.Wrap(endDelegation(event, "sender"), "end delegation")
 			}
 		case storageTypes.EventTypeWithdrawRewards:
-			if err := parseWithdrawRewards(ctx, msg, events[i].Data); err != nil {
+			if err := parseWithdrawRewards(ctx, msg, event.Data); err != nil {
 				return err
 			}
 		case storageTypes.EventTypeDelegate:
-			delegate, err := decode.NewDelegate(events[i].Data)
+			delegate, err := decode.NewDelegate(event.Data)
 			if err != nil {
 				return err
 			}
@@ -112,15 +114,8 @@ func processDelegate(ctx *context.Context, events []storage.Event, msg *storage.
 			ctx.AddValidator(*delegation.Validator)
 
 			if newFormat {
-				if err := endDelegation(events[i], "delegator"); err != nil {
-					return errors.Wrap(err, "end delegation")
-				}
-				*idx = i + 1
-				return nil
+				return errors.Wrap(endDelegation(event, "delegator"), "end delegation")
 			}
 		}
-
 	}
-
-	return nil
 }

--- a/pkg/indexer/parser/events/delegate_test.go
+++ b/pkg/indexer/parser/events/delegate_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/celenium-io/celestia-indexer/internal/currency"
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -18,11 +17,12 @@ import (
 func Test_handleDelegate(t *testing.T) {
 	ts := time.Now()
 	tests := []struct {
-		name       string
-		ctx        *context.Context
-		events     []storage.Event
-		msg        *storage.Message
-		idx        *int
+		name   string
+		ctx    *context.Context
+		events []storage.Event
+		msg    *storage.Message
+		idx    int
+
 		delegation *storage.Delegation
 	}{
 		{
@@ -125,7 +125,8 @@ func Test_handleDelegate(t *testing.T) {
 					"ValidatorAddress": "celestiavaloper1uqj5ul7jtpskk9ste9mfv6jvh0y3w34vtpz3gw",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			delegation: &storage.Delegation{
 				Amount: types.NumericFromInt64(5690000),
 				Address: &storage.Address{
@@ -215,7 +216,8 @@ func Test_handleDelegate(t *testing.T) {
 					"ValidatorAddress": "celestiavaloper1uqj5ul7jtpskk9ste9mfv6jvh0y3w34vtpz3gw",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			delegation: &storage.Delegation{
 				Amount: types.NumericFromInt64(5690000),
 				Address: &storage.Address{
@@ -368,7 +370,8 @@ func Test_handleDelegate(t *testing.T) {
 					"ValidatorAddress": "celestiavaloper1uqj5ul7jtpskk9ste9mfv6jvh0y3w34vtpz3gw",
 				},
 			},
-			idx: testsuite.Ptr(7),
+			idx: 7,
+
 			delegation: &storage.Delegation{
 				Amount: types.NumericFromInt64(100000000),
 				Address: &storage.Address{
@@ -458,7 +461,8 @@ func Test_handleDelegate(t *testing.T) {
 					"ValidatorAddress": "celestiavaloper1jt9w26mpxxjsk63mvd4m2ynj0af09cslh5d096",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			delegation: &storage.Delegation{
 				Amount: types.NumericFromInt64(45000000),
 				Address: &storage.Address{
@@ -493,7 +497,9 @@ func Test_handleDelegate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := handleDelegate(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			c.Skip(tt.idx)
+			err := handleDelegate(tt.ctx, c, tt.msg)
 			require.NoError(t, err)
 			require.EqualValues(t, 1, tt.ctx.Delegations.Len())
 			for _, value := range tt.ctx.Delegations.All() {

--- a/pkg/indexer/parser/events/deposit.go
+++ b/pkg/indexer/parser/events/deposit.go
@@ -11,34 +11,36 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleDeposit(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleDeposit(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/cosmos.gov.v1.MsgDeposit" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/cosmos.gov.v1.MsgDeposit" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processDeposit(ctx, events, msg, idx)
+	c.Next()
+	return processDeposit(ctx, c, msg)
 }
 
-func processDeposit(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	*idx += 4
-	if len(events) <= *idx {
-		return errors.Errorf("proposal deposit unexpected events length: %d", len(events))
+func processDeposit(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	c.Skip(4)
+	event, ok := c.Peek()
+	if !ok {
+		return errors.New("proposal deposit unexpected events length")
 	}
-	if events[*idx].Type != types.EventTypeProposalDeposit {
-		return errors.Errorf("proposal deposit unexpected event type: %s", events[*idx].Type)
+	if event.Type != types.EventTypeProposalDeposit {
+		return errors.Errorf("proposal deposit unexpected event type: %s", event.Type)
 	}
 
-	proposalId, err := decoder.Uint64FromMap(events[*idx].Data, "proposal_id")
+	proposalId, err := decoder.Uint64FromMap(event.Data, "proposal_id")
 	if err != nil {
-		return errors.Errorf("submit proposal can't receive proposal id: %##v", events[*idx].Data)
+		return errors.Errorf("submit proposal can't receive proposal id: %##v", event.Data)
 	}
-	depositAmount, err := decoder.NumericAmountFromMap(events[*idx].Data, "amount")
+	depositAmount, err := decoder.NumericAmountFromMap(event.Data, "amount")
 	if err != nil {
 		return errors.Wrap(err, "parse deposit amount")
 	}
@@ -48,12 +50,16 @@ func processDeposit(ctx *context.Context, events []storage.Event, msg *storage.M
 		Status:  types.ProposalStatusInactive,
 	}
 
-	*idx += 1
-	for ; len(events) > *idx; *idx += 1 {
-		if events[*idx].Type == types.EventTypeProposalDeposit {
-			votingPeriodStart, err := decoder.Uint64FromMap(events[*idx].Data, "voting_period_start")
+	c.Next()
+	for {
+		event, ok := c.Peek()
+		if !ok {
+			break
+		}
+		if event.Type == types.EventTypeProposalDeposit {
+			votingPeriodStart, err := decoder.Uint64FromMap(event.Data, "voting_period_start")
 			if err != nil {
-				return errors.Errorf("submit proposal can't receive voting_period_start: %##v", events[*idx].Data)
+				return errors.Errorf("submit proposal can't receive voting_period_start: %##v", event.Data)
 			}
 			if votingPeriodStart == proposalId {
 				msg.Proposal.Status = types.ProposalStatusActive
@@ -62,9 +68,10 @@ func processDeposit(ctx *context.Context, events []storage.Event, msg *storage.M
 			break
 		}
 
-		if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "" {
+		if action := decoder.StringFromMap(event.Data, "action"); action != "" {
 			break
 		}
+		c.Next()
 	}
 	ctx.AddProposal(msg.Proposal)
 

--- a/pkg/indexer/parser/events/deposit_test.go
+++ b/pkg/indexer/parser/events/deposit_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -17,11 +16,12 @@ import (
 func Test_handleDeposit(t *testing.T) {
 	ts := time.Now()
 	tests := []struct {
-		name     string
-		ctx      *context.Context
-		events   []storage.Event
-		msg      *storage.Message
-		idx      *int
+		name   string
+		ctx    *context.Context
+		events []storage.Event
+		msg    *storage.Message
+		idx    int
+
 		proposal storage.Proposal
 	}{
 		{
@@ -88,7 +88,8 @@ func Test_handleDeposit(t *testing.T) {
 				Type:   types.MsgDeposit,
 				Height: 1745041,
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			proposal: storage.Proposal{
 				Id:             2,
 				ActivationTime: &ts,
@@ -153,7 +154,8 @@ func Test_handleDeposit(t *testing.T) {
 				Type:   types.MsgDeposit,
 				Height: 1745041,
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			proposal: storage.Proposal{
 				Id:      2,
 				Status:  types.ProposalStatusInactive,
@@ -223,7 +225,8 @@ func Test_handleDeposit(t *testing.T) {
 				Type:   types.MsgDeposit,
 				Height: 1745041,
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			proposal: storage.Proposal{
 				Id:             7,
 				ActivationTime: &ts,
@@ -287,7 +290,8 @@ func Test_handleDeposit(t *testing.T) {
 				Type:   types.MsgDeposit,
 				Height: 1745041,
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			proposal: storage.Proposal{
 				Id:      7,
 				Status:  types.ProposalStatusInactive,
@@ -300,7 +304,9 @@ func Test_handleDeposit(t *testing.T) {
 			tt.ctx.Block = &storage.Block{
 				Time: ts,
 			}
-			err := handleDeposit(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			c.Skip(tt.idx)
+			err := handleDeposit(tt.ctx, c, tt.msg)
 			require.NoError(t, err)
 			require.NotNil(t, tt.msg.Proposal)
 			require.Equal(t, tt.proposal, *tt.msg.Proposal)

--- a/pkg/indexer/parser/events/exec.go
+++ b/pkg/indexer/parser/events/exec.go
@@ -10,22 +10,23 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleExec(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleExec(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/cosmos.authz.v1beta1.MsgExec" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/cosmos.authz.v1beta1.MsgExec" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
+	c.Next()
 
-	return processExec(ctx, events, msg, idx)
+	return processExec(ctx, c, msg)
 }
 
-func processExec(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
+func processExec(ctx *context.Context, c *Cursor, msg *storage.Message) error {
 	for i := range msg.InternalMsgs {
 		msgs, err := getInternalDataForExec(msg.Data, i)
 		if err != nil {
@@ -40,31 +41,31 @@ func processExec(ctx *context.Context, events []storage.Event, msg *storage.Mess
 
 		switch msg.InternalMsgs[i] {
 		case "/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation":
-			if err := processCancelUnbonding(ctx, events, internalMessage, idx); err != nil {
+			if err := processCancelUnbonding(ctx, c, internalMessage); err != nil {
 				return err
 			}
 		case "/cosmos.staking.v1beta1.MsgDelegate":
-			if err := processDelegate(ctx, events, internalMessage, idx); err != nil {
+			if err := processDelegate(ctx, c, internalMessage); err != nil {
 				return err
 			}
 		case "/cosmos.staking.v1beta1.MsgBeginRedelegate":
-			if err := processRedelegate(ctx, events, internalMessage, idx); err != nil {
+			if err := processRedelegate(ctx, c, internalMessage); err != nil {
 				return err
 			}
 		case "/cosmos.staking.v1beta1.MsgUndelegate":
-			if err := processUndelegate(ctx, events, internalMessage, idx); err != nil {
+			if err := processUndelegate(ctx, c, internalMessage); err != nil {
 				return err
 			}
 		case msgWithdrawValidatorCommission:
-			if err := processWithdrawValidatorCommission(ctx, events, internalMessage, idx); err != nil {
+			if err := processWithdrawValidatorCommission(ctx, c, internalMessage); err != nil {
 				return err
 			}
 		case "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward":
-			if err := processWithdrawDelegatorRewards(ctx, events, internalMessage, idx); err != nil {
+			if err := processWithdrawDelegatorRewards(ctx, c, internalMessage); err != nil {
 				return err
 			}
 		case "/cosmos.slashing.v1beta1.MsgUnjail":
-			if err := processUnjail(ctx, events, internalMessage, idx); err != nil {
+			if err := processUnjail(ctx, c, internalMessage); err != nil {
 				return err
 			}
 		case "/celestia.signal.v1.MsgSignalVersion":
@@ -72,34 +73,35 @@ func processExec(ctx *context.Context, events []storage.Event, msg *storage.Mess
 			if err != nil {
 				return err
 			}
-			if err := processSignalVersion(ctx, events, msg, data, idx); err != nil {
+			if err := processSignalVersion(ctx, c, msg, data); err != nil {
 				return err
 			}
 		case "/cosmos.gov.v1beta1.MsgVote", "/cosmos.gov.v1.MsgVote", "/cosmos.gov.v1.MsgVoteWeighted", "/cosmos.gov.v1beta1.MsgVoteWeighted":
-			if err := processVote(ctx, events, internalMessage, idx); err != nil {
+			if err := processVote(ctx, c, internalMessage); err != nil {
 				return err
 			}
 		case "/celestia.forwarding.v1.MsgForward":
-			if err := processForward(ctx, events, internalMessage, idx); err != nil {
+			if err := processForward(ctx, c, internalMessage); err != nil {
 				return err
 			}
 		default:
-			for j := *idx; j < len(events); j++ {
-				authMsgIdxPtr, err := decoder.AuthMsgIndexFromMap(events[*idx].Data)
+			for {
+				event, ok := c.Peek()
+				if !ok {
+					break
+				}
+				authMsgIdxPtr, err := decoder.AuthMsgIndexFromMap(event.Data)
 				if err != nil {
 					return err
 				}
 				if authMsgIdxPtr == nil {
 					break
 				}
-
 				if *authMsgIdxPtr != int64(i) {
 					break
 				}
-
-				*idx = j + 1
+				c.Next()
 			}
-
 		}
 	}
 

--- a/pkg/indexer/parser/events/exec_test.go
+++ b/pkg/indexer/parser/events/exec_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -20,7 +19,7 @@ func Test_handleExec(t *testing.T) {
 		ctx    *context.Context
 		events []storage.Event
 		msg    *storage.Message
-		idx    *int
+		idx    int
 	}{
 		{
 			name: "multiple delegations",
@@ -346,7 +345,7 @@ func Test_handleExec(t *testing.T) {
 					"/cosmos.staking.v1beta1.MsgDelegate",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		}, {
 			name: "multiple undelegations",
 			ctx:  context.NewContext(),
@@ -516,7 +515,7 @@ func Test_handleExec(t *testing.T) {
 					"/cosmos.staking.v1beta1.MsgUndelegate",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		}, {
 			name: "MsgWithdrawDelegatorReward",
 			ctx:  context.NewContext(),
@@ -688,7 +687,7 @@ func Test_handleExec(t *testing.T) {
 					"/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward",
 				},
 			},
-			idx: testsuite.Ptr(7),
+			idx: 7,
 		}, {
 			name: "unknown message",
 			ctx:  context.NewContext(),
@@ -784,7 +783,7 @@ func Test_handleExec(t *testing.T) {
 					"/cosmos.authz.v1beta1.MsgGrant",
 				},
 			},
-			idx: testsuite.Ptr(9),
+			idx: 9,
 		}, {
 			name: "signal version",
 			ctx:  context.NewContext(),
@@ -872,7 +871,7 @@ func Test_handleExec(t *testing.T) {
 					"/celestia.signal.v1.Msg/SignalVersion",
 				},
 			},
-			idx: testsuite.Ptr(7),
+			idx: 7,
 		}, {
 			name: "vote",
 			ctx:  context.NewContext(),
@@ -966,7 +965,7 @@ func Test_handleExec(t *testing.T) {
 					"/cosmos.gov.v1.MsgVoteWeighted",
 				},
 			},
-			idx: testsuite.Ptr(7),
+			idx: 7,
 		}, {
 			name: "withdraw commissions and delegator rewards",
 			ctx:  context.NewContext(),
@@ -1139,7 +1138,7 @@ func Test_handleExec(t *testing.T) {
 					"/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission",
 				},
 			},
-			idx: testsuite.Ptr(7),
+			idx: 7,
 		}, {
 			name: "withdraw commissions, delegator rewards and delegate",
 			ctx:  context.NewContext(),
@@ -1366,7 +1365,7 @@ func Test_handleExec(t *testing.T) {
 					"/cosmos.staking.v1beta1.MsgDelegate",
 				},
 			},
-			idx: testsuite.Ptr(7),
+			idx: 7,
 		},
 	}
 	for _, tt := range tests {
@@ -1375,7 +1374,9 @@ func Test_handleExec(t *testing.T) {
 			Height: tt.msg.Height,
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			err := handleExec(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			c.Skip(tt.idx)
+			err := handleExec(tt.ctx, c, tt.msg)
 			require.NoError(t, err)
 		})
 	}

--- a/pkg/indexer/parser/events/forward.go
+++ b/pkg/indexer/parser/events/forward.go
@@ -13,31 +13,37 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleForward(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleForward(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/celestia.forwarding.v1.MsgForward" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/celestia.forwarding.v1.MsgForward" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processForward(ctx, events, msg, idx)
+	c.Next()
+	return processForward(ctx, c, msg)
 }
 
-func processForward(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
+func processForward(ctx *context.Context, c *Cursor, msg *storage.Message) error {
 	var forwarding = storage.Forwarding{
 		Height: msg.Height,
 		Time:   msg.Time,
 		TxId:   msg.TxId,
 	}
 
-	for ; len(events) > *idx; *idx += 1 {
-		switch events[*idx].Type {
+	for {
+		event, ok := c.Peek()
+		if !ok {
+			break
+		}
+
+		switch event.Type {
 		case types.EventTypeCelestiaforwardingv1EventTokenForwarded:
-			forwarded, err := decode.NewEventTokenForwarded(events[*idx].Data)
+			forwarded, err := decode.NewEventTokenForwarded(event.Data)
 			if err != nil {
 				return errors.Wrap(err, "decoding token forwarded event")
 			}
@@ -45,11 +51,8 @@ func processForward(ctx *context.Context, events []storage.Event, msg *storage.M
 			// Pre-v8 format lacks token_id — drain remaining events for this
 			// message without creating a forwarding entity.
 			if forwarded.TokenId == "" {
-				for *idx += 1; len(events) > *idx; *idx += 1 {
-					if decoder.StringFromMap(events[*idx].Data, "action") != "" {
-						return nil
-					}
-				}
+				c.Next()
+				c.SkipToNext("action")
 				return nil
 			}
 
@@ -78,25 +81,28 @@ func processForward(ctx *context.Context, events []storage.Event, msg *storage.M
 			if err = ctx.AddAddress(forwarding.Address); err != nil {
 				return errors.Wrap(err, "add forwarding address")
 			}
+			c.Next()
 
 		case types.EventTypeHyperlanewarpv1EventSendRemoteTransfer:
-			event, err := decode.NewHyperlaneSendTransferEvent(events[*idx].Data)
+			transferEvent, err := decode.NewHyperlaneSendTransferEvent(event.Data)
 			if err != nil {
 				return errors.Wrap(err, "parse hyperlane send transfer event")
 			}
 
-			recipient, err := util.DecodeHexAddress(event.Recipient)
+			recipient, err := util.DecodeHexAddress(transferEvent.Recipient)
 			if err != nil {
 				return errors.Wrap(err, "decode recipient address")
 			}
-			forwarding.DestDomain = event.DestinationDomain
+			forwarding.DestDomain = transferEvent.DestinationDomain
 			forwarding.DestRecipient = recipient.Bytes()
+			c.Next()
 
 		default:
-			if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "" {
+			if action := decoder.StringFromMap(event.Data, "action"); action != "" {
 				ctx.AddForwarding(&forwarding)
 				return nil
 			}
+			c.Next()
 		}
 	}
 

--- a/pkg/indexer/parser/events/forward_test.go
+++ b/pkg/indexer/parser/events/forward_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -20,29 +19,28 @@ import (
 func Test_handleForward(t *testing.T) {
 	ts := time.Now()
 
-	t.Run("nil event index", func(t *testing.T) {
+	t.Run("nil event cursor", func(t *testing.T) {
 		ctx := context.NewContext()
 		msg := &storage.Message{
 			Type:   types.MsgForward,
 			Height: 100,
 			Time:   ts,
 		}
-		err := handleForward(ctx, nil, msg, nil)
+		err := handleForward(ctx, nil, msg)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "nil event index")
+		require.Contains(t, err.Error(), "nil event cursor")
 	})
 
 	t.Run("nil message", func(t *testing.T) {
 		ctx := context.NewContext()
-		idx := 0
-		err := handleForward(ctx, nil, nil, &idx)
+		c := NewCursor(nil)
+		err := handleForward(ctx, c, nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "nil message")
 	})
 
 	t.Run("unexpected action", func(t *testing.T) {
 		ctx := context.NewContext()
-		idx := 0
 		msg := &storage.Message{
 			Type:   types.MsgForward,
 			Height: 100,
@@ -57,7 +55,8 @@ func Test_handleForward(t *testing.T) {
 				},
 			},
 		}
-		err := handleForward(ctx, events, msg, &idx)
+		c := NewCursor(events)
+		err := handleForward(ctx, c, msg)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unexpected event action")
 	})
@@ -65,7 +64,6 @@ func Test_handleForward(t *testing.T) {
 	// Mirrors real tx 0A5524EE...: EventSendRemoteTransfer precedes EventTokenForwarded.
 	t.Run("success: send remote transfer then token forwarded", func(t *testing.T) {
 		ctx := context.NewContext()
-		idx := 0
 		msg := &storage.Message{
 			Type:   types.MsgForward,
 			Height: 10955535,
@@ -102,7 +100,8 @@ func Test_handleForward(t *testing.T) {
 			},
 		}
 
-		err := handleForward(ctx, events, msg, &idx)
+		c := NewCursor(events)
+		err := handleForward(ctx, c, msg)
 		require.NoError(t, err)
 		require.Len(t, ctx.Forwardings, 1)
 
@@ -121,7 +120,6 @@ func Test_handleForward(t *testing.T) {
 	// Intermediate non-forwarding events (coin_spent, coin_received, etc.) are skipped.
 	t.Run("skips intermediate events without action key", func(t *testing.T) {
 		ctx := context.NewContext()
-		idx := 0
 		msg := &storage.Message{
 			Type:   types.MsgForward,
 			Height: 100,
@@ -170,7 +168,8 @@ func Test_handleForward(t *testing.T) {
 			},
 		}
 
-		err := handleForward(ctx, events, msg, &idx)
+		c := NewCursor(events)
+		err := handleForward(ctx, c, msg)
 		require.NoError(t, err)
 		require.Len(t, ctx.Forwardings, 1)
 		require.Equal(t, uint64(1), ctx.Forwardings[0].DestDomain)
@@ -179,7 +178,6 @@ func Test_handleForward(t *testing.T) {
 
 	t.Run("stops at next action event", func(t *testing.T) {
 		ctx := context.NewContext()
-		idx := 0
 		msg := &storage.Message{
 			Type:   types.MsgForward,
 			Height: 100,
@@ -209,15 +207,18 @@ func Test_handleForward(t *testing.T) {
 			},
 		}
 
-		err := handleForward(ctx, events, msg, &idx)
+		c := NewCursor(events)
+		err := handleForward(ctx, c, msg)
 		require.NoError(t, err)
 		require.Len(t, ctx.Forwardings, 1)
-		require.Equal(t, 2, idx, "index should stop at next action event")
+
+		next, ok := c.Peek()
+		require.True(t, ok, "cursor should stop at the next action event, not consume it")
+		require.Equal(t, "/cosmos.bank.v1beta1.MsgSend", next.Data["action"])
 	})
 
 	t.Run("multiple messages in sequence", func(t *testing.T) {
 		ctx := context.NewContext()
-		idx := testsuite.Ptr(0)
 		events := []storage.Event{
 			// First MsgForward
 			{
@@ -278,8 +279,9 @@ func Test_handleForward(t *testing.T) {
 			{Type: types.MsgForward, Height: 100, Time: ts},
 		}
 
+		c := NewCursor(events)
 		for i := range msgs {
-			err := handleForward(ctx, events, msgs[i], idx)
+			err := handleForward(ctx, c, msgs[i])
 			require.NoError(t, err)
 		}
 
@@ -297,7 +299,6 @@ func Test_handleForward(t *testing.T) {
 	// still saved; DestDomain and DestRecipient remain zero/nil.
 	t.Run("token forwarded without send remote transfer", func(t *testing.T) {
 		ctx := context.NewContext()
-		idx := 0
 		msg := &storage.Message{
 			Type:   types.MsgForward,
 			Height: 100,
@@ -322,7 +323,8 @@ func Test_handleForward(t *testing.T) {
 			},
 		}
 
-		err := handleForward(ctx, events, msg, &idx)
+		c := NewCursor(events)
+		err := handleForward(ctx, c, msg)
 		require.NoError(t, err)
 		require.Len(t, ctx.Forwardings, 1)
 
@@ -337,7 +339,6 @@ func Test_handleForward(t *testing.T) {
 
 	t.Run("no events after action", func(t *testing.T) {
 		ctx := context.NewContext()
-		idx := 0
 		msg := &storage.Message{
 			Type:   types.MsgForward,
 			Height: 100,
@@ -351,7 +352,8 @@ func Test_handleForward(t *testing.T) {
 			},
 		}
 
-		err := handleForward(ctx, events, msg, &idx)
+		c := NewCursor(events)
+		err := handleForward(ctx, c, msg)
 		require.NoError(t, err)
 		require.Empty(t, ctx.Forwardings)
 	})
@@ -361,7 +363,6 @@ func Test_handleForward(t *testing.T) {
 	// is still emitted. The parser must return an error because token_id is absent.
 	t.Run("pre-v8 format: missing token_id returns error", func(t *testing.T) {
 		ctx := context.NewContext()
-		idx := 0
 		msg := &storage.Message{
 			Type:   types.MsgForward,
 			Height: 10727934,
@@ -409,7 +410,8 @@ func Test_handleForward(t *testing.T) {
 			},
 		}
 
-		err := handleForward(ctx, events, msg, &idx)
+		c := NewCursor(events)
+		err := handleForward(ctx, c, msg)
 		require.NoError(t, err)
 		require.Empty(t, ctx.Forwardings)
 	})

--- a/pkg/indexer/parser/events/guard_boundary_test.go
+++ b/pkg/indexer/parser/events/guard_boundary_test.go
@@ -21,7 +21,7 @@ func msgEvent(action string) storage.Event {
 	}
 }
 
-type guardHandlerFn func(*context.Context, []storage.Event, *storage.Message, *int) error
+type guardHandlerFn func(*context.Context, *Cursor, *storage.Message) error
 
 // Test_eventHandlers_truncatedEvents_returnErrorNotPanic verifies that every
 // event handler which advances *idx by a fixed offset guards the subsequent
@@ -102,9 +102,9 @@ func Test_eventHandlers_truncatedEvents_returnErrorNotPanic(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			idx := 0
+			c := NewCursor(tt.events)
 			require.NotPanics(t, func() {
-				err := tt.handler(context.NewContext(), tt.events, tt.msg, &idx)
+				err := tt.handler(context.NewContext(), c, tt.msg)
 				require.Error(t, err)
 			})
 		})
@@ -127,9 +127,9 @@ func Test_submitProposal_secondGuard_returnErrorNotPanic(t *testing.T) {
 	}
 	msg := &storage.Message{Type: types.MsgUnknown, Proposal: &storage.Proposal{}}
 
-	idx := 0
+	c := NewCursor(events)
 	require.NotPanics(t, func() {
-		err := handleSubmitProposal(context.NewContext(), events, msg, &idx)
+		err := handleSubmitProposal(context.NewContext(), c, msg)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "after parsing proposal id")
 	})

--- a/pkg/indexer/parser/events/handlers.go
+++ b/pkg/indexer/parser/events/handlers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/decoder"
 )
 
-type EventHandler func(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error
+type EventHandler func(ctx *context.Context, c *Cursor, msg *storage.Message) error
 
 var eventHandlers = map[storageTypes.MsgType]EventHandler{
 	storageTypes.MsgDelegate:                       handleDelegate,
@@ -53,35 +53,38 @@ var eventHandlers = map[storageTypes.MsgType]EventHandler{
 	storageTypes.MsgSubmitMessages:                 handleSubmitZkISMMessages,
 }
 
-func handle(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int, eventHandlers map[storageTypes.MsgType]EventHandler, stopKey string) error {
+func handle(ctx *context.Context, c *Cursor, msg *storage.Message, eventHandlers map[storageTypes.MsgType]EventHandler, stopKey string) error {
 	if handler, ok := eventHandlers[msg.Type]; ok {
-		return handler(ctx, events, msg, idx)
+		return handler(ctx, c, msg)
 	}
 
-	// if event handler is not found list events to another action
-	*idx++
-
-	startIndex := *idx
-	for _, event := range events[startIndex:] {
-		if event.Type != storageTypes.EventTypeMessage {
-			*idx++
-			continue
+	// if event handler is not found, skip events up to the next message
+	// carrying an event of type "message" whose Data has a non-empty
+	// stopKey (mirrors MsgEvents' boundary check, but additionally
+	// requires EventTypeMessage — a plain stopKey match on some other
+	// event type does not end the scan here).
+	c.Next()
+	for {
+		event, ok := c.Peek()
+		if !ok {
+			return nil
 		}
-		if action := decoder.StringFromMap(event.Data, stopKey); action == "" {
-			*idx++
-			continue
+		if event.Type == storageTypes.EventTypeMessage && decoder.StringFromMap(event.Data, stopKey) != "" {
+			return nil
 		}
-		break
+		c.Next()
 	}
-
-	return nil
 }
 
-func Handle(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if err := handle(ctx, events, msg, idx, eventHandlers, "action"); err != nil {
+// Handle dispatches msg to the registered top-level handler for its type
+// (or skips its events if none is registered), then advances c to the
+// "action" boundary event that starts the next message in the
+// transaction, ready for the next call to Handle.
+func Handle(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if err := handle(ctx, c, msg, eventHandlers, "action"); err != nil {
 		return err
 	}
-	toTheNextAction(events, idx)
+	c.SkipToNext("action")
 	return nil
 }
 
@@ -122,15 +125,4 @@ var ibcEventHandlers = map[storageTypes.MsgType]EventHandler{
 	storageTypes.MsgCreateInterchainSecurityModule: processCreateZkISM,
 	storageTypes.MsgUpdateInterchainSecurityModule: processUpdateZkISM,
 	storageTypes.MsgSubmitMessages:                 processSubmitZkISMMessages,
-}
-
-func toTheNextAction(events []storage.Event, idx *int) {
-	if len(events)-1 <= *idx {
-		return
-	}
-	var action = decoder.StringFromMap(events[*idx].Data, "action")
-	for action == "" && len(events)-1 > *idx {
-		*idx += 1
-		action = decoder.StringFromMap(events[*idx].Data, "action")
-	}
 }

--- a/pkg/indexer/parser/events/handlers_boundary_test.go
+++ b/pkg/indexer/parser/events/handlers_boundary_test.go
@@ -18,7 +18,6 @@ func Test_Handle_boundarySafety(t *testing.T) {
 		name        string
 		events      []storage.Event
 		msg         *storage.Message
-		idx         int
 		expectError bool
 	}{
 		{
@@ -44,19 +43,16 @@ func Test_Handle_boundarySafety(t *testing.T) {
 				Height: 100,
 				Data:   map[string]any{},
 			},
-			idx:         0,
 			expectError: false,
 		},
 		{
-			name:   "empty events array",
-			events: []storage.Event{},
-			msg: &storage.Message{
-				Type:   types.MsgSend,
-				Height: 100,
-				Data:   map[string]any{},
-			},
-			idx:         0,
-			expectError: true, // will fail because events[0] doesn't exist
+			// Previously this panicked: handleSend indexed events[0] directly on
+			// an empty slice. Cursor.Peek() can't go out of bounds, so this is
+			// now a graceful "unexpected event action" error, not a crash.
+			name:        "empty events array",
+			events:      []storage.Event{},
+			msg:         &storage.Message{Type: types.MsgSend, Height: 100, Data: map[string]any{}},
+			expectError: true,
 		},
 		{
 			name: "unhandled message type at end of events",
@@ -74,7 +70,6 @@ func Test_Handle_boundarySafety(t *testing.T) {
 				Height: 100,
 				Data:   map[string]any{},
 			},
-			idx:         0,
 			expectError: false,
 		},
 		{
@@ -105,7 +100,6 @@ func Test_Handle_boundarySafety(t *testing.T) {
 				Height: 100,
 				Data:   map[string]any{},
 			},
-			idx:         0,
 			expectError: false,
 		},
 	}
@@ -113,17 +107,16 @@ func Test_Handle_boundarySafety(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.NewContext()
-			idx := tt.idx
+			c := NewCursor(tt.events)
 
+			var err error
+			require.NotPanics(t, func() {
+				err = Handle(ctx, c, tt.msg)
+			})
 			if tt.expectError {
-				require.Panics(t, func() {
-					_ = Handle(ctx, tt.events, tt.msg, &idx)
-				})
+				require.Error(t, err)
 			} else {
-				require.NotPanics(t, func() {
-					err := Handle(ctx, tt.events, tt.msg, &idx)
-					require.NoError(t, err)
-				})
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -132,13 +125,11 @@ func Test_Handle_boundarySafety(t *testing.T) {
 // Test_handle_sliceIterationSafety tests the internal handle function for slice iteration safety
 func Test_handle_sliceIterationSafety(t *testing.T) {
 	tests := []struct {
-		name        string
-		events      []storage.Event
-		msg         *storage.Message
-		idx         int
-		handlers    map[types.MsgType]EventHandler
-		stopKey     string
-		expectPanic bool
+		name     string
+		events   []storage.Event
+		msg      *storage.Message
+		handlers map[types.MsgType]EventHandler
+		stopKey  string
 	}{
 		{
 			name: "iteration reaches end safely",
@@ -161,10 +152,8 @@ func Test_handle_sliceIterationSafety(t *testing.T) {
 				Height: 100,
 				Data:   map[string]any{},
 			},
-			idx:         0,
-			handlers:    map[types.MsgType]EventHandler{},
-			stopKey:     "action",
-			expectPanic: false,
+			handlers: map[types.MsgType]EventHandler{},
+			stopKey:  "action",
 		},
 		{
 			name: "starts at last element",
@@ -182,10 +171,8 @@ func Test_handle_sliceIterationSafety(t *testing.T) {
 				Height: 100,
 				Data:   map[string]any{},
 			},
-			idx:         0,
-			handlers:    map[types.MsgType]EventHandler{},
-			stopKey:     "action",
-			expectPanic: false,
+			handlers: map[types.MsgType]EventHandler{},
+			stopKey:  "action",
 		},
 		{
 			name: "no message events to stop at",
@@ -213,47 +200,45 @@ func Test_handle_sliceIterationSafety(t *testing.T) {
 				Height: 100,
 				Data:   map[string]any{},
 			},
-			idx:         0,
-			handlers:    map[types.MsgType]EventHandler{},
-			stopKey:     "action",
-			expectPanic: false,
+			handlers: map[types.MsgType]EventHandler{},
+			stopKey:  "action",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.NewContext()
-			idx := tt.idx
+			c := NewCursor(tt.events)
 
-			if tt.expectPanic {
-				require.Panics(t, func() {
-					_ = handle(ctx, tt.events, tt.msg, &idx, tt.handlers, tt.stopKey)
-				})
-			} else {
-				require.NotPanics(t, func() {
-					err := handle(ctx, tt.events, tt.msg, &idx, tt.handlers, tt.stopKey)
-					require.NoError(t, err)
-				})
-			}
+			require.NotPanics(t, func() {
+				err := handle(ctx, c, tt.msg, tt.handlers, tt.stopKey)
+				require.NoError(t, err)
+			})
 		})
 	}
 }
 
-// Test_toTheNextAction_incrementSafety ensures toTheNextAction doesn't cause index out of bounds
+// Test_toTheNextAction_incrementSafety ensures Cursor.SkipToNext("action")
+// doesn't cause index out of bounds (this used to test the standalone
+// toTheNextAction helper, which SkipToNext replaced).
 func Test_toTheNextAction_incrementSafety(t *testing.T) {
 	tests := []struct {
-		name      string
-		events    []storage.Event
-		startIdx  int
-		expectIdx int
+		name           string
+		events         []storage.Event
+		startIdx       int
+		wantAtEnd      bool
+		wantActionData string
 	}{
 		{
 			name:      "empty slice",
 			events:    []storage.Event{},
 			startIdx:  0,
-			expectIdx: 0, // should not increment
+			wantAtEnd: true,
 		},
 		{
+			// SkipToNext drains an event with an empty action (it isn't a
+			// boundary) instead of stopping short of it, so the cursor lands
+			// at the true end here rather than staying put.
 			name: "single element with empty action",
 			events: []storage.Event{
 				{
@@ -264,7 +249,7 @@ func Test_toTheNextAction_incrementSafety(t *testing.T) {
 				},
 			},
 			startIdx:  0,
-			expectIdx: 0, // at boundary, should not increment
+			wantAtEnd: true,
 		},
 		{
 			name: "two elements, start at first",
@@ -282,8 +267,8 @@ func Test_toTheNextAction_incrementSafety(t *testing.T) {
 					},
 				},
 			},
-			startIdx:  0,
-			expectIdx: 1,
+			startIdx:       0,
+			wantActionData: "/some.action",
 		},
 		{
 			name: "start at penultimate position with empty action",
@@ -307,10 +292,13 @@ func Test_toTheNextAction_incrementSafety(t *testing.T) {
 					},
 				},
 			},
-			startIdx:  1,
-			expectIdx: 2,
+			startIdx:       1,
+			wantActionData: "/action",
 		},
 		{
+			// Same canonicalization as the "single element" case above: both
+			// remaining events have an empty action, so SkipToNext drains
+			// them all and lands at the true end.
 			name: "all empty actions",
 			events: []storage.Event{
 				{
@@ -327,17 +315,26 @@ func Test_toTheNextAction_incrementSafety(t *testing.T) {
 				},
 			},
 			startIdx:  0,
-			expectIdx: 1, // stops at last element
+			wantAtEnd: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			idx := tt.startIdx
+			c := NewCursor(tt.events)
+			c.Skip(tt.startIdx)
+
 			require.NotPanics(t, func() {
-				toTheNextAction(tt.events, &idx)
+				c.SkipToNext("action")
 			})
-			require.Equal(t, tt.expectIdx, idx, "index should match expected value")
+
+			event, ok := c.Peek()
+			if tt.wantAtEnd {
+				require.False(t, ok, "cursor should have reached the end")
+				return
+			}
+			require.True(t, ok)
+			require.Equal(t, tt.wantActionData, event.Data["action"])
 		})
 	}
 }
@@ -348,7 +345,6 @@ func Test_recvPacket_incrementBy2Safety(t *testing.T) {
 		name   string
 		events []storage.Event
 		msg    *storage.Message
-		idx    int
 	}{
 		{
 			name: "exactly 2 elements after current",
@@ -380,7 +376,6 @@ func Test_recvPacket_incrementBy2Safety(t *testing.T) {
 					},
 				},
 			},
-			idx: 0,
 		},
 		{
 			name: "only 1 element after increment",
@@ -407,16 +402,15 @@ func Test_recvPacket_incrementBy2Safety(t *testing.T) {
 					},
 				},
 			},
-			idx: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.NewContext()
-			idx := tt.idx
+			c := NewCursor(tt.events)
 			require.NotPanics(t, func() {
-				err := handleRecvPacket(ctx, tt.events, tt.msg, &idx)
+				err := handleRecvPacket(ctx, c, tt.msg)
 				require.NoError(t, err)
 			})
 		})

--- a/pkg/indexer/parser/events/process_message.go
+++ b/pkg/indexer/parser/events/process_message.go
@@ -16,33 +16,32 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleHyperlaneProcessMessage(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleHyperlaneProcessMessage(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/hyperlane.core.v1.MsgProcessMessage" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/hyperlane.core.v1.MsgProcessMessage" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processHyperlaneProcessMessage(ctx, events, msg, idx)
+	c.Next()
+	return processHyperlaneProcessMessage(ctx, c, msg)
 }
 
-func processHyperlaneProcessMessage(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	end := false
-
+func processHyperlaneProcessMessage(ctx *context.Context, c *Cursor, msg *storage.Message) error {
 	var transfer = &storage.HLTransfer{
 		Height: ctx.Block.Height,
 		Time:   ctx.Block.Time,
 		TxId:   msg.TxId,
 	}
 
-	for !end {
-		switch events[*idx].Type {
+	for event := range c.MsgEvents("action") {
+		switch event.Type {
 		case types.EventTypeHyperlanecorev1EventProcess:
-			processEvent, err := decode.NewHyperlaneProcessEvent(events[*idx].Data)
+			processEvent, err := decode.NewHyperlaneProcessEvent(event.Data)
 			if err != nil {
 				return errors.Wrap(err, "parse hyperlane process event")
 			}
@@ -82,54 +81,50 @@ func processHyperlaneProcessMessage(ctx *context.Context, events []storage.Event
 			}
 			ctx.AddHlTransfer(transfer)
 		case types.EventTypeHyperlanewarpv1EventReceiveRemoteTransfer:
-			event, err := decode.NewHyperlaneReceiveTransferEvent(events[*idx].Data)
+			receiveEvent, err := decode.NewHyperlaneReceiveTransferEvent(event.Data)
 			if err != nil {
 				return errors.Wrap(err, "parse hyperlane receive transfer event")
 			}
 
-			if err := makeHyperlaneTransferAddress(ctx, event.Sender, transfer, msg.Height); err != nil {
+			if err := makeHyperlaneTransferAddress(ctx, receiveEvent.Sender, transfer, msg.Height); err != nil {
 				return errors.Wrap(err, "makeHyperlaneTransferAddress")
 			}
-			if err := makeHyperlaneTransferAddress(ctx, event.Recipient, transfer, msg.Height); err != nil {
+			if err := makeHyperlaneTransferAddress(ctx, receiveEvent.Recipient, transfer, msg.Height); err != nil {
 				return errors.Wrap(err, "makeHyperlaneTransferAddress")
 			}
 
-			transfer.Denom = event.Denom
-			transfer.Amount = event.Amount
-			tokenId, err := util.DecodeHexAddress(event.TokenId)
+			transfer.Denom = receiveEvent.Denom
+			transfer.Amount = receiveEvent.Amount
+			tokenId, err := util.DecodeHexAddress(receiveEvent.TokenId)
 			if err != nil {
 				return errors.Wrap(err, "decode token id")
 			}
 			transfer.Token = &storage.HLToken{
 				TokenId:          tokenId.Bytes(),
 				ReceiveTransfers: 1,
-				Received:         event.Amount,
+				Received:         receiveEvent.Amount,
 				Type:             types.HLTokenTypeCollateral,
 			}
 		case types.EventTypeHyperlanecorepostDispatchv1EventGasPayment:
-			event, err := decode.NewHyperlaneGasPaymentEvent(events[*idx].Data)
+			gasEvent, err := decode.NewHyperlaneGasPaymentEvent(event.Data)
 			if err != nil {
 				return errors.Wrap(err, "parse hyperlane gas payment event")
 			}
 
-			igpId, err := util.DecodeHexAddress(event.IgpId)
+			igpId, err := util.DecodeHexAddress(gasEvent.IgpId)
 			if err != nil {
 				return errors.Wrap(err, "decode igp id")
 			}
 			transfer.GasPayment = &storage.HLGasPayment{
 				Height:    ctx.Block.Height,
 				Time:      ctx.Block.Time,
-				Amount:    event.Amount,
-				GasAmount: event.GasAmount,
+				Amount:    gasEvent.Amount,
+				GasAmount: gasEvent.GasAmount,
 				Igp: &storage.HLIGP{
 					IgpId: igpId.Bytes(),
 				},
 			}
 		}
-
-		action := decoder.StringFromMap(events[*idx].Data, "action")
-		end = len(events)-1 == *idx || action != "" || end
-		*idx += 1
 	}
 
 	return nil

--- a/pkg/indexer/parser/events/process_message_test.go
+++ b/pkg/indexer/parser/events/process_message_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -20,7 +19,7 @@ func Test_handleHyperlaneProcessMessage(t *testing.T) {
 		ctx    *context.Context
 		events []storage.Event
 		msg    []*storage.Message
-		idx    *int
+		idx    int
 	}{
 		{
 			name: "test 1",
@@ -101,7 +100,7 @@ func Test_handleHyperlaneProcessMessage(t *testing.T) {
 					Height: 1036866,
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		},
 	}
 	for _, tt := range tests {
@@ -111,7 +110,9 @@ func Test_handleHyperlaneProcessMessage(t *testing.T) {
 				Time:   time.Now(),
 			}
 			for i := range tt.msg {
-				err := handleHyperlaneProcessMessage(tt.ctx, tt.events, tt.msg[i], tt.idx)
+				c := NewCursor(tt.events)
+				c.Skip(tt.idx)
+				err := handleHyperlaneProcessMessage(tt.ctx, c, tt.msg[i])
 				require.NoError(t, err)
 				require.NotEmpty(t, tt.ctx.HlTransfers)
 

--- a/pkg/indexer/parser/events/recv_packet.go
+++ b/pkg/indexer/parser/events/recv_packet.go
@@ -12,32 +12,34 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleRecvPacket(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleRecvPacket(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	action := decoder.StringFromMap(events[*idx].Data, "action")
+	event, _ := c.Peek()
+	action := decoder.StringFromMap(event.Data, "action")
 	isValidMsg := action == "/ibc.core.channel.v1.MsgRecvPacket"
 	if !isValidMsg {
-		return errors.Errorf("unexpected event action %s for message type %s (idx=%d, event=%s)", action, msg.Type.String(), *idx, events[*idx].Type)
+		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processRecvPacket(ctx, events, msg, idx)
+	c.Next()
+	return processRecvPacket(ctx, c, msg)
 }
 
-func processRecvPacket(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if len(events)-1 < *idx || events[*idx].Type == storageTypes.EventTypeMessage {
+func processRecvPacket(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	event, ok := c.Peek()
+	if !ok || event.Type == storageTypes.EventTypeMessage {
 		ctx.RemoveLastIbcTransfer()
 		return nil
 	}
 
 	transfer := ctx.GetLastIbcTransfer()
 	var chanId string
-	if events[*idx].Type == storageTypes.EventTypeRecvPacket && transfer != nil {
-		rp, err := decode.NewRecvPacket(events[*idx].Data)
+	if event.Type == storageTypes.EventTypeRecvPacket && transfer != nil {
+		rp, err := decode.NewRecvPacket(event.Data)
 		if err != nil {
 			return err
 		}
@@ -45,23 +47,25 @@ func processRecvPacket(ctx *context.Context, events []storage.Event, msg *storag
 		chanId = rp.DstChannel
 	}
 
-	*idx += 2
+	c.Skip(2)
 
-	if len(events)-1 < *idx {
+	event, ok = c.Peek()
+	if !ok {
 		return nil
 	}
 
-	if events[*idx].Type == storageTypes.EventTypeIbccallbackerrorIcs27Packet {
-		*idx += 1
-		if len(events)-1 < *idx {
+	if event.Type == storageTypes.EventTypeIbccallbackerrorIcs27Packet {
+		c.Next()
+		if _, ok := c.Peek(); !ok {
 			ctx.RemoveLastIbcTransfer()
 			ctx.DeleteIbcChannel(chanId)
 			return nil
 		}
+		event, _ = c.Peek()
 	}
 
-	if events[*idx].Type == storageTypes.EventTypeWriteAcknowledgement {
-		*idx += 2
+	if event.Type == storageTypes.EventTypeWriteAcknowledgement {
+		c.Skip(2)
 		ctx.RemoveLastIbcTransfer()
 		ctx.DeleteIbcChannel(chanId)
 		return nil
@@ -92,18 +96,18 @@ func processRecvPacket(ctx *context.Context, events []storage.Event, msg *storag
 				return errors.Wrap(err, "decode message in RecvPacket")
 			}
 
-			if err := handle(ctx, events, &decodedMsg.Msg, idx, ibcEventHandlers, "module"); err != nil {
+			if err := handle(ctx, c, &decodedMsg.Msg, ibcEventHandlers, "module"); err != nil {
 				return errors.Wrap(err, "handle IBC msg event")
 			}
 		}
 
 	case "transfer":
-		var action = decoder.StringFromMap(events[*idx].Data, "action")
+		current, _ := c.Peek()
+		action := decoder.StringFromMap(current.Data, "action")
 
 		if transfer == nil {
 			return nil
 		}
-
 		if err := ctx.AddAddress(transfer.Sender); err != nil {
 			return err
 		}
@@ -112,19 +116,24 @@ func processRecvPacket(ctx *context.Context, events []storage.Event, msg *storag
 		}
 
 		hasFtp := false
-		for action == "" && len(events)-1 > *idx {
-			*idx += 1
-			action = decoder.StringFromMap(events[*idx].Data, "action")
+		for action == "" {
+			if len(c.Remaining()) <= 1 {
+				break
+			}
+			c.Next()
+			next, _ := c.Peek()
+			action = decoder.StringFromMap(next.Data, "action")
 
-			if events[*idx].Type == storageTypes.EventTypeFungibleTokenPacket {
+			if next.Type == storageTypes.EventTypeFungibleTokenPacket {
 				hasFtp = true
-				ftp := decode.NewFungibleTokenPacket(events[*idx].Data)
+				ftp := decode.NewFungibleTokenPacket(next.Data)
 				if ftp.Error != "" {
 					ctx.RemoveLastIbcTransfer()
 					ctx.DeleteIbcChannel(chanId)
 				}
 			}
 		}
+
 		if !hasFtp {
 			ctx.RemoveLastIbcTransfer()
 			ctx.DeleteIbcChannel(chanId)

--- a/pkg/indexer/parser/events/recv_packet_test.go
+++ b/pkg/indexer/parser/events/recv_packet_test.go
@@ -10,7 +10,6 @@ import (
 	"cosmossdk.io/math"
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	cosmosTypes "github.com/cosmos/cosmos-sdk/types"
 
@@ -28,7 +27,7 @@ func Test_handleRecvPacket(t *testing.T) {
 		ctx    *context.Context
 		events []storage.Event
 		msg    []*storage.Message
-		idx    *int
+		idx    int
 	}{
 		{
 			name: "recv packet test 1",
@@ -160,7 +159,7 @@ func Test_handleRecvPacket(t *testing.T) {
 					},
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		}, {
 			name: "recv packet test 2",
 			ctx:  context.NewContext(),
@@ -451,7 +450,7 @@ func Test_handleRecvPacket(t *testing.T) {
 					},
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		}, {
 			name: "recv packet test 3",
 			ctx:  context.NewContext(),
@@ -625,7 +624,7 @@ func Test_handleRecvPacket(t *testing.T) {
 					},
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		}, {
 			name: "recv packet test 4",
 			ctx:  context.NewContext(),
@@ -877,7 +876,7 @@ func Test_handleRecvPacket(t *testing.T) {
 					},
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		}, {
 			name: "recv packet test 5",
 			ctx:  context.NewContext(),
@@ -1052,7 +1051,7 @@ func Test_handleRecvPacket(t *testing.T) {
 					},
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		}, {
 			name: "failed ICA recv packet with ibccallbackerror followed by successful ICA recv packet",
 			ctx:  context.NewContext(),
@@ -1274,7 +1273,7 @@ func Test_handleRecvPacket(t *testing.T) {
 					},
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		},
 	}
 	for _, tt := range tests {
@@ -1283,8 +1282,10 @@ func Test_handleRecvPacket(t *testing.T) {
 				Height: tt.events[0].Height,
 				Time:   time.Now().UTC(),
 			}
+			c := NewCursor(tt.events)
+			c.Skip(tt.idx)
 			for i := range tt.msg {
-				err := handleRecvPacket(tt.ctx, tt.events, tt.msg[i], tt.idx)
+				err := handleRecvPacket(tt.ctx, c, tt.msg[i])
 				require.NoError(t, err)
 				if len(tt.ctx.IbcTransfers) > 0 {
 					require.NotEmpty(t, tt.ctx.IbcTransfers[0].ConnectionId)
@@ -1298,8 +1299,7 @@ func Test_handleRecvPacket(t *testing.T) {
 					}
 				}
 
-				toTheNextAction(tt.events, tt.idx)
-
+				c.SkipToNext("action")
 			}
 		})
 	}

--- a/pkg/indexer/parser/events/redelegate.go
+++ b/pkg/indexer/parser/events/redelegate.go
@@ -14,39 +14,42 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleRedelegate(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleRedelegate(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/cosmos.staking.v1beta1.MsgBeginRedelegate" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/cosmos.staking.v1beta1.MsgBeginRedelegate" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processRedelegate(ctx, events, msg, idx)
+	c.Next()
+	return processRedelegate(ctx, c, msg)
 }
 
-func processRedelegate(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	var (
-		msgIdx    = decoder.StringFromMap(events[*idx].Data, "msg_index")
-		newFormat = msgIdx != ""
-	)
+func processRedelegate(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	first, _ := c.Peek()
+	msgIdx := decoder.StringFromMap(first.Data, "msg_index")
+	newFormat := msgIdx != ""
 
-	for i := *idx; i < len(events); i++ {
-		switch events[i].Type {
+	for {
+		event, ok := c.Next()
+		if !ok {
+			return nil
+		}
+		switch event.Type {
 		case storageTypes.EventTypeMessage:
-			if module := decoder.StringFromMap(events[i].Data, "module"); module == storageTypes.ModuleNameStaking.String() {
-				*idx = i + 1
+			if module := decoder.StringFromMap(event.Data, "module"); module == storageTypes.ModuleNameStaking.String() {
 				return nil
 			}
 		case storageTypes.EventTypeWithdrawRewards:
-			if err := parseWithdrawRewards(ctx, msg, events[i].Data); err != nil {
+			if err := parseWithdrawRewards(ctx, msg, event.Data); err != nil {
 				return err
 			}
 		case storageTypes.EventTypeRedelegate:
-			redelegate, err := decode.NewRedelegate(events[i].Data)
+			redelegate, err := decode.NewRedelegate(event.Data)
 			if err != nil {
 				return err
 			}
@@ -146,11 +149,8 @@ func processRedelegate(ctx *context.Context, events []storage.Event, msg *storag
 			})
 
 			if newFormat {
-				*idx = i + 1
 				return nil
 			}
 		}
 	}
-
-	return nil
 }

--- a/pkg/indexer/parser/events/redelegate_test.go
+++ b/pkg/indexer/parser/events/redelegate_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/celenium-io/celestia-indexer/internal/currency"
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -18,11 +17,12 @@ import (
 func Test_handleRedelegate(t *testing.T) {
 	ts := time.Now()
 	tests := []struct {
-		name         string
-		ctx          *context.Context
-		events       []storage.Event
-		msg          *storage.Message
-		idx          *int
+		name   string
+		ctx    *context.Context
+		events []storage.Event
+		msg    *storage.Message
+		idx    int
+
 		redelegation *storage.Redelegation
 	}{
 		{
@@ -111,7 +111,8 @@ func Test_handleRedelegate(t *testing.T) {
 					"ValidatorSrcAddress": "celestiavaloper1uqj5ul7jtpskk9ste9mfv6jvh0y3w34vtpz3gw",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			redelegation: &storage.Redelegation{
 				Time:           ts,
 				Height:         841682,
@@ -214,7 +215,8 @@ func Test_handleRedelegate(t *testing.T) {
 					"ValidatorSrcAddress": "celestiavaloper1e2p4u5vqwgum7pm9vhp0yjvl58gvhfc6yfatw4",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			redelegation: &storage.Redelegation{
 				Time:           ts,
 				Height:         241,
@@ -390,7 +392,8 @@ func Test_handleRedelegate(t *testing.T) {
 					"ValidatorSrcAddress": "celestiavaloper1uwmf03ke52vld2sa9khs0nslpgzwsm5xs5e4pn",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			redelegation: &storage.Redelegation{
 				Time:           ts,
 				Height:         315,
@@ -525,7 +528,8 @@ func Test_handleRedelegate(t *testing.T) {
 					"ValidatorSrcAddress": "celestiavaloper19mm3s0y676453w3ja58d376ysd84wlf6hq8ae3",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			redelegation: &storage.Redelegation{
 				Time:           ts,
 				Height:         315,
@@ -661,7 +665,8 @@ func Test_handleRedelegate(t *testing.T) {
 					"ValidatorSrcAddress": "celestiavaloper19mm3s0y676453w3ja58d376ysd84wlf6hq8ae3",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			redelegation: &storage.Redelegation{
 				Time:           ts,
 				Height:         315,
@@ -714,7 +719,9 @@ func Test_handleRedelegate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := handleRedelegate(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			c.Skip(tt.idx)
+			err := handleRedelegate(tt.ctx, c, tt.msg)
 			require.NoError(t, err)
 			require.Len(t, tt.ctx.Redelegations, 1)
 			require.Equal(t, *tt.redelegation, tt.ctx.Redelegations[0])

--- a/pkg/indexer/parser/events/remote_transfer.go
+++ b/pkg/indexer/parser/events/remote_transfer.go
@@ -13,34 +13,32 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleHyperlaneRemoteTransfer(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleHyperlaneRemoteTransfer(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/hyperlane.warp.v1.MsgRemoteTransfer" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/hyperlane.warp.v1.MsgRemoteTransfer" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processHyperlaneRemoteTransfer(ctx, events, msg, idx)
+	c.Next()
+	return processHyperlaneRemoteTransfer(ctx, c, msg)
 }
 
-func processHyperlaneRemoteTransfer(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	end := false
-
+func processHyperlaneRemoteTransfer(ctx *context.Context, c *Cursor, msg *storage.Message) error {
 	var transfer = &storage.HLTransfer{
 		Height: ctx.Block.Height,
 		Time:   ctx.Block.Time,
 		TxId:   msg.TxId,
 	}
 
-	for !end {
-
-		switch events[*idx].Type {
+	for event := range c.MsgEvents("action") {
+		switch event.Type {
 		case types.EventTypeHyperlanecorev1EventDispatch:
-			dispatchEvent, err := decode.NewHyperlaneDispatchEvent(events[*idx].Data)
+			dispatchEvent, err := decode.NewHyperlaneDispatchEvent(event.Data)
 			if err != nil {
 				return errors.Wrap(err, "parse hyperlane dispatch event")
 			}
@@ -64,54 +62,50 @@ func processHyperlaneRemoteTransfer(ctx *context.Context, events []storage.Event
 
 			ctx.AddHlTransfer(transfer)
 		case types.EventTypeHyperlanewarpv1EventSendRemoteTransfer:
-			event, err := decode.NewHyperlaneSendTransferEvent(events[*idx].Data)
+			sendEvent, err := decode.NewHyperlaneSendTransferEvent(event.Data)
 			if err != nil {
 				return errors.Wrap(err, "parse hyperlane send transfer event")
 			}
 
-			if err := makeHyperlaneTransferAddress(ctx, event.Sender, transfer, msg.Height); err != nil {
+			if err := makeHyperlaneTransferAddress(ctx, sendEvent.Sender, transfer, msg.Height); err != nil {
 				return errors.Wrap(err, "makeHyperlaneTransferAddress")
 			}
-			if err := makeHyperlaneTransferAddress(ctx, event.Recipient, transfer, msg.Height); err != nil {
+			if err := makeHyperlaneTransferAddress(ctx, sendEvent.Recipient, transfer, msg.Height); err != nil {
 				return errors.Wrap(err, "makeHyperlaneTransferAddress")
 			}
 
-			transfer.Denom = event.Denom
-			transfer.Amount = event.Amount
-			tokenId, err := util.DecodeHexAddress(event.TokenId)
+			transfer.Denom = sendEvent.Denom
+			transfer.Amount = sendEvent.Amount
+			tokenId, err := util.DecodeHexAddress(sendEvent.TokenId)
 			if err != nil {
 				return errors.Wrap(err, "decode token id")
 			}
 			transfer.Token = &storage.HLToken{
 				TokenId:       tokenId.Bytes(),
 				SentTransfers: 1,
-				Sent:          event.Amount,
+				Sent:          sendEvent.Amount,
 				Type:          types.HLTokenTypeCollateral,
 			}
 		case types.EventTypeHyperlanecorepostDispatchv1EventGasPayment:
-			event, err := decode.NewHyperlaneGasPaymentEvent(events[*idx].Data)
+			gasEvent, err := decode.NewHyperlaneGasPaymentEvent(event.Data)
 			if err != nil {
 				return errors.Wrap(err, "parse hyperlane gas payment event")
 			}
 
-			igpId, err := util.DecodeHexAddress(event.IgpId)
+			igpId, err := util.DecodeHexAddress(gasEvent.IgpId)
 			if err != nil {
 				return errors.Wrap(err, "decode igp id")
 			}
 			transfer.GasPayment = &storage.HLGasPayment{
 				Height:    ctx.Block.Height,
 				Time:      ctx.Block.Time,
-				Amount:    event.Amount,
-				GasAmount: event.GasAmount,
+				Amount:    gasEvent.Amount,
+				GasAmount: gasEvent.GasAmount,
 				Igp: &storage.HLIGP{
 					IgpId: igpId.Bytes(),
 				},
 			}
 		}
-
-		action := decoder.StringFromMap(events[*idx].Data, "action")
-		end = len(events)-1 == *idx || action != "" || end
-		*idx += 1
 	}
 
 	return nil

--- a/pkg/indexer/parser/events/remote_transfer_test.go
+++ b/pkg/indexer/parser/events/remote_transfer_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -20,7 +19,7 @@ func Test_handleHyperlaneRemoteTransfer(t *testing.T) {
 		ctx    *context.Context
 		events []storage.Event
 		msg    []*storage.Message
-		idx    *int
+		idx    int
 	}{
 		{
 			name: "test 1",
@@ -138,7 +137,7 @@ func Test_handleHyperlaneRemoteTransfer(t *testing.T) {
 					Height: 1036866,
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		},
 	}
 	for _, tt := range tests {
@@ -148,7 +147,9 @@ func Test_handleHyperlaneRemoteTransfer(t *testing.T) {
 				Time:   time.Now(),
 			}
 			for i := range tt.msg {
-				err := handleHyperlaneRemoteTransfer(tt.ctx, tt.events, tt.msg[i], tt.idx)
+				c := NewCursor(tt.events)
+				c.Skip(tt.idx)
+				err := handleHyperlaneRemoteTransfer(tt.ctx, c, tt.msg[i])
 				require.NoError(t, err)
 				require.NotEmpty(t, tt.ctx.HlTransfers)
 

--- a/pkg/indexer/parser/events/send.go
+++ b/pkg/indexer/parser/events/send.go
@@ -10,33 +10,35 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleSend(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleSend(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	action := decoder.StringFromMap(events[*idx].Data, "action")
+	event, _ := c.Peek()
+	action := decoder.StringFromMap(event.Data, "action")
 	isValidMsg := action == "/cosmos.bank.v1beta1.MsgSend"
 	if !isValidMsg {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processSend(ctx, events, msg, idx)
+	c.Next()
+	return processSend(ctx, c, msg)
 }
 
-func processSend(_ *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if len(events) <= *idx {
+func processSend(_ *context.Context, c *Cursor, _ *storage.Message) error {
+	event, ok := c.Peek()
+	if !ok {
 		return errors.New("not enough events for send")
 	}
-	msgIdx := decoder.StringFromMap(events[*idx].Data, "msg_index")
+	msgIdx := decoder.StringFromMap(event.Data, "msg_index")
 	newFormat := msgIdx != ""
 
 	if newFormat {
-		*idx += 4
+		c.Skip(4)
 	} else {
-		*idx += 5
+		c.Skip(5)
 	}
 
 	return nil

--- a/pkg/indexer/parser/events/send_test.go
+++ b/pkg/indexer/parser/events/send_test.go
@@ -8,19 +8,16 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSendHandler(t *testing.T) {
 	tests := []struct {
-		name       string
-		ctx        *context.Context
-		events     []storage.Event
-		msg        *storage.Message
-		idx        *int
-		requireIdx int
+		name   string
+		ctx    *context.Context
+		events []storage.Event
+		msg    *storage.Message
 	}{
 		{
 			name: "send test 1",
@@ -72,8 +69,6 @@ func TestSendHandler(t *testing.T) {
 				Type:   types.MsgSend,
 				Height: 1745041,
 			},
-			idx:        testsuite.Ptr(0),
-			requireIdx: 6,
 		}, {
 			name: "send test 2",
 			ctx:  context.NewContext(),
@@ -123,15 +118,18 @@ func TestSendHandler(t *testing.T) {
 				Type:   types.MsgSend,
 				Height: 1745041,
 			},
-			idx:        testsuite.Ptr(0),
-			requireIdx: 5,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := handleSend(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			err := handleSend(tt.ctx, c, tt.msg)
 			require.NoError(t, err)
-			require.Equal(t, tt.requireIdx, *tt.idx)
+
+			// Both fixtures are exactly consumed: the handler skips straight
+			// to the end of the message's own events.
+			_, ok := c.Peek()
+			require.False(t, ok, "cursor should be exhausted after handling send")
 		})
 	}
 }

--- a/pkg/indexer/parser/events/set_mailbox.go
+++ b/pkg/indexer/parser/events/set_mailbox.go
@@ -13,86 +13,84 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleSetMailbox(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleSetMailbox(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/hyperlane.core.v1.MsgSetMailbox" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/hyperlane.core.v1.MsgSetMailbox" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processSetMailbox(ctx, events, msg, idx)
+	c.Next()
+	return processSetMailbox(ctx, c, msg)
 }
 
-func processSetMailbox(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	end := false
-	for !end {
-		if events[*idx].Type == types.EventTypeHyperlanecorev1EventSetMailbox {
-			setMailbox, err := decode.NewSetMailbox(events[*idx].Data)
-			if err != nil {
-				return err
-			}
-
-			mailboxId, err := util.DecodeHexAddress(setMailbox.MailboxId)
-			if err != nil {
-				return errors.Wrap(err, "decode mailbox id")
-			}
-
-			mailbox := &storage.HLMailbox{
-				Height:     ctx.Block.Height,
-				Time:       ctx.Block.Time,
-				Mailbox:    mailboxId.Bytes(),
-				InternalId: mailboxId.GetInternalId(),
-				Owner: &storage.Address{
-					Address:    setMailbox.Owner,
-					Height:     msg.Height,
-					LastHeight: msg.Height,
-					Balances:   []storage.Balance{storage.EmptyBalance()},
-				},
-			}
-			if err := ctx.AddAddress(mailbox.Owner); err != nil {
-				return errors.Wrap(err, "add address")
-			}
-
-			if len(setMailbox.DefaultIsm) > 0 && setMailbox.DefaultIsm != null {
-				defaultIsm, err := util.DecodeHexAddress(setMailbox.DefaultIsm)
-				if err != nil {
-					return errors.Wrapf(err, "decode default ISM: %s", setMailbox.DefaultIsm)
-				}
-				mailbox.DefaultIsm = defaultIsm.Bytes()
-			}
-
-			if len(setMailbox.DefaultHook) > 0 && setMailbox.DefaultHook != null {
-				defaultHook, err := util.DecodeHexAddress(setMailbox.DefaultHook)
-				if err != nil {
-					return errors.Wrapf(err, "decode default hook: %s", setMailbox.DefaultHook)
-				}
-				mailbox.DefaultHook = defaultHook.Bytes()
-			}
-
-			if len(setMailbox.NewOwner) > 0 && setMailbox.NewOwner != setMailbox.Owner {
-				newOwner := &storage.Address{
-					Address:    setMailbox.NewOwner,
-					Balances:   []storage.Balance{storage.EmptyBalance()},
-					Height:     msg.Height,
-					LastHeight: msg.Height,
-				}
-				if err := ctx.AddAddress(newOwner); err != nil {
-					return errors.Wrap(err, "add address")
-				}
-				mailbox.Owner = newOwner
-			}
-
-			ctx.AddHlMailbox(mailbox)
-			end = true
+func processSetMailbox(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	for event := range c.MsgEvents("action") {
+		if event.Type != types.EventTypeHyperlanecorev1EventSetMailbox {
+			continue
 		}
 
-		action := decoder.StringFromMap(events[*idx].Data, "action")
-		end = len(events)-1 == *idx || action != "" || end
-		*idx += 1
+		setMailbox, err := decode.NewSetMailbox(event.Data)
+		if err != nil {
+			return err
+		}
+
+		mailboxId, err := util.DecodeHexAddress(setMailbox.MailboxId)
+		if err != nil {
+			return errors.Wrap(err, "decode mailbox id")
+		}
+
+		mailbox := &storage.HLMailbox{
+			Height:     ctx.Block.Height,
+			Time:       ctx.Block.Time,
+			Mailbox:    mailboxId.Bytes(),
+			InternalId: mailboxId.GetInternalId(),
+			Owner: &storage.Address{
+				Address:    setMailbox.Owner,
+				Height:     msg.Height,
+				LastHeight: msg.Height,
+				Balances:   []storage.Balance{storage.EmptyBalance()},
+			},
+		}
+		if err := ctx.AddAddress(mailbox.Owner); err != nil {
+			return errors.Wrap(err, "add address")
+		}
+
+		if len(setMailbox.DefaultIsm) > 0 && setMailbox.DefaultIsm != null {
+			defaultIsm, err := util.DecodeHexAddress(setMailbox.DefaultIsm)
+			if err != nil {
+				return errors.Wrapf(err, "decode default ISM: %s", setMailbox.DefaultIsm)
+			}
+			mailbox.DefaultIsm = defaultIsm.Bytes()
+		}
+
+		if len(setMailbox.DefaultHook) > 0 && setMailbox.DefaultHook != null {
+			defaultHook, err := util.DecodeHexAddress(setMailbox.DefaultHook)
+			if err != nil {
+				return errors.Wrapf(err, "decode default hook: %s", setMailbox.DefaultHook)
+			}
+			mailbox.DefaultHook = defaultHook.Bytes()
+		}
+
+		if len(setMailbox.NewOwner) > 0 && setMailbox.NewOwner != setMailbox.Owner {
+			newOwner := &storage.Address{
+				Address:    setMailbox.NewOwner,
+				Balances:   []storage.Balance{storage.EmptyBalance()},
+				Height:     msg.Height,
+				LastHeight: msg.Height,
+			}
+			if err := ctx.AddAddress(newOwner); err != nil {
+				return errors.Wrap(err, "add address")
+			}
+			mailbox.Owner = newOwner
+		}
+
+		ctx.AddHlMailbox(mailbox)
+		break
 	}
 	return nil
 }

--- a/pkg/indexer/parser/events/set_mailbox_test.go
+++ b/pkg/indexer/parser/events/set_mailbox_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -17,11 +16,12 @@ import (
 func Test_handleSetMailbox(t *testing.T) {
 	ts := time.Now()
 	tests := []struct {
-		name    string
-		ctx     *context.Context
-		events  []storage.Event
-		msg     *storage.Message
-		idx     *int
+		name   string
+		ctx    *context.Context
+		events []storage.Event
+		msg    *storage.Message
+		idx    int
+
 		mailbox *storage.HLMailbox
 	}{
 		{
@@ -55,7 +55,8 @@ func Test_handleSetMailbox(t *testing.T) {
 				Height: 1036866,
 				Time:   ts,
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			mailbox: &storage.HLMailbox{
 				Height:      1036866,
 				Time:        ts,
@@ -77,7 +78,9 @@ func Test_handleSetMailbox(t *testing.T) {
 				Height: 1036866,
 				Time:   ts,
 			}
-			err := handleSetMailbox(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			c.Skip(tt.idx)
+			err := handleSetMailbox(tt.ctx, c, tt.msg)
 			require.NoError(t, err)
 			require.NotEmpty(t, tt.ctx.HlMailboxes.Len())
 
@@ -91,11 +94,12 @@ func Test_handleSetMailbox(t *testing.T) {
 func Test_handleSetMailbox_newOwner(t *testing.T) {
 	ts := time.Now()
 	tests := []struct {
-		name    string
-		ctx     *context.Context
-		events  []storage.Event
-		msg     *storage.Message
-		idx     *int
+		name   string
+		ctx    *context.Context
+		events []storage.Event
+		msg    *storage.Message
+		idx    int
+
 		mailbox *storage.HLMailbox
 	}{
 		{
@@ -129,7 +133,8 @@ func Test_handleSetMailbox_newOwner(t *testing.T) {
 				Height: 1036866,
 				Time:   ts,
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			mailbox: &storage.HLMailbox{
 				Height:      1036866,
 				Time:        ts,
@@ -151,7 +156,9 @@ func Test_handleSetMailbox_newOwner(t *testing.T) {
 				Height: 1036866,
 				Time:   ts,
 			}
-			err := handleSetMailbox(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			c.Skip(tt.idx)
+			err := handleSetMailbox(tt.ctx, c, tt.msg)
 			require.NoError(t, err)
 			require.NotEmpty(t, tt.ctx.HlMailboxes.Len())
 

--- a/pkg/indexer/parser/events/set_token.go
+++ b/pkg/indexer/parser/events/set_token.go
@@ -13,56 +13,56 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleSetToken(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleSetToken(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/hyperlane.warp.v1.MsgSetToken" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/hyperlane.warp.v1.MsgSetToken" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processSetToken(ctx, events, msg, idx)
+	c.Next()
+	return processSetToken(ctx, c, msg)
 }
 
-func processSetToken(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	end := false
-	for !end {
-		if events[*idx].Type == types.EventTypeHyperlanewarpv1EventSetToken {
-			setToken, err := decode.NewSetToken(events[*idx].Data)
-			if err != nil {
-				return err
-			}
-
-			if setToken.NewOwner != "" {
-				tokenId, err := util.DecodeHexAddress(setToken.TokenId)
-				if err != nil {
-					return errors.Wrap(err, "decode token id")
-				}
-
-				token := &storage.HLToken{
-					TokenId: tokenId.Bytes(),
-					Owner: &storage.Address{
-						Address:    setToken.NewOwner,
-						Height:     msg.Height,
-						LastHeight: msg.Height,
-						Balances:   []storage.Balance{storage.EmptyBalance()},
-					},
-					Type: types.HLTokenTypeCollateral,
-				}
-				ctx.AddHlToken(token)
-				if err := ctx.AddAddress(token.Owner); err != nil {
-					return errors.Wrap(err, "add address")
-				}
-				end = true
-			}
+func processSetToken(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	for event := range c.MsgEvents("action") {
+		if event.Type != types.EventTypeHyperlanewarpv1EventSetToken {
+			continue
 		}
 
-		action := decoder.StringFromMap(events[*idx].Data, "action")
-		end = len(events)-1 == *idx || action != "" || end
-		*idx += 1
+		setToken, err := decode.NewSetToken(event.Data)
+		if err != nil {
+			return err
+		}
+
+		if setToken.NewOwner == "" {
+			continue
+		}
+
+		tokenId, err := util.DecodeHexAddress(setToken.TokenId)
+		if err != nil {
+			return errors.Wrap(err, "decode token id")
+		}
+
+		token := &storage.HLToken{
+			TokenId: tokenId.Bytes(),
+			Owner: &storage.Address{
+				Address:    setToken.NewOwner,
+				Height:     msg.Height,
+				LastHeight: msg.Height,
+				Balances:   []storage.Balance{storage.EmptyBalance()},
+			},
+			Type: types.HLTokenTypeCollateral,
+		}
+		ctx.AddHlToken(token)
+		if err := ctx.AddAddress(token.Owner); err != nil {
+			return errors.Wrap(err, "add address")
+		}
+		break
 	}
 
 	return nil

--- a/pkg/indexer/parser/events/set_token_test.go
+++ b/pkg/indexer/parser/events/set_token_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -21,7 +20,7 @@ func Test_handleSetToken(t *testing.T) {
 		events    []storage.Event
 		msg       []*storage.Message
 		wantEmpty bool
-		idx       *int
+		idx       int
 	}{
 		{
 			name: "test 1",
@@ -52,7 +51,8 @@ func Test_handleSetToken(t *testing.T) {
 					Height: 1036866,
 				},
 			},
-			idx:       testsuite.Ptr(0),
+			idx: 0,
+
 			wantEmpty: false,
 		}, {
 			name: "test 2: empty new owner",
@@ -83,7 +83,8 @@ func Test_handleSetToken(t *testing.T) {
 					Height: 1036866,
 				},
 			},
-			idx:       testsuite.Ptr(0),
+			idx: 0,
+
 			wantEmpty: true,
 		},
 	}
@@ -94,7 +95,9 @@ func Test_handleSetToken(t *testing.T) {
 				Time:   time.Now(),
 			}
 			for i := range tt.msg {
-				err := handleSetToken(tt.ctx, tt.events, tt.msg[i], tt.idx)
+				c := NewCursor(tt.events)
+				c.Skip(tt.idx)
+				err := handleSetToken(tt.ctx, c, tt.msg[i])
 				require.NoError(t, err)
 				if !tt.wantEmpty {
 					require.NotEmpty(t, tt.ctx.HlTokens.Len())

--- a/pkg/indexer/parser/events/signal_version.go
+++ b/pkg/indexer/parser/events/signal_version.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func processSignalVersion(ctx *context.Context, _ []storage.Event, msg *storage.Message, data map[string]any, idx *int) error {
+func processSignalVersion(ctx *context.Context, c *Cursor, msg *storage.Message, data map[string]any) error {
 	version, err := decoder.Uint64(data, "Version")
 	if err != nil {
 		return errors.Wrap(err, "get signal version in exec")
@@ -41,6 +41,6 @@ func processSignalVersion(ctx *context.Context, _ []storage.Event, msg *storage.
 		Height:       msg.Height,
 		Time:         msg.Time,
 	})
-	*idx += 1
+	c.Skip(1)
 	return nil
 }

--- a/pkg/indexer/parser/events/submit_proposal.go
+++ b/pkg/indexer/parser/events/submit_proposal.go
@@ -11,9 +11,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleSubmitProposal(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleSubmitProposal(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
@@ -21,49 +21,52 @@ func handleSubmitProposal(ctx *context.Context, events []storage.Event, msg *sto
 	if msg.Proposal == nil {
 		return nil
 	}
-	action := decoder.StringFromMap(events[*idx].Data, "action")
+	event, _ := c.Peek()
+	action := decoder.StringFromMap(event.Data, "action")
 	isValid := action == "/cosmos.gov.v1beta1.MsgSubmitProposal" || action == "/cosmos.gov.v1.MsgSubmitProposal"
 	if !isValid {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processSubmitProposal(ctx, events, msg, idx)
+	c.Next()
+	return processSubmitProposal(ctx, c, msg)
 }
 
-func processSubmitProposal(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if len(events) <= *idx {
+func processSubmitProposal(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	event, ok := c.Peek()
+	if !ok {
 		return errors.New("not enough events for submit proposal")
 	}
-	if events[*idx].Type != types.EventTypeSubmitProposal {
-		return errors.Errorf("submit proposal unexpected event type: %s", events[*idx].Type)
+	if event.Type != types.EventTypeSubmitProposal {
+		return errors.Errorf("submit proposal unexpected event type: %s", event.Type)
 	}
 
-	proposalId, err := decoder.Uint64FromMap(events[*idx].Data, "proposal_id")
+	proposalId, err := decoder.Uint64FromMap(event.Data, "proposal_id")
 	if err != nil {
-		return errors.Errorf("submit proposal can't receive proposal id: %##v", events[*idx].Data)
+		return errors.Errorf("submit proposal can't receive proposal id: %##v", event.Data)
 	}
 	msg.Proposal.Id = proposalId
-	*idx += 5
-	if len(events) <= *idx {
+	c.Skip(5)
+	event, ok = c.Peek()
+	if !ok {
 		return errors.New("not enough events for submit proposal after parsing proposal id")
 	}
 
-	if events[*idx].Type != types.EventTypeProposalDeposit {
-		return errors.Errorf("submit proposal unexpected event type: %s", events[*idx].Type)
+	if event.Type != types.EventTypeProposalDeposit {
+		return errors.Errorf("submit proposal unexpected event type: %s", event.Type)
 	}
-	deposit, err := decoder.NumericAmountFromMap(events[*idx].Data, "amount")
+	deposit, err := decoder.NumericAmountFromMap(event.Data, "amount")
 	if err != nil {
 		return errors.Wrap(err, "parse proposal deposit amount")
 	}
 	msg.Proposal.Deposit = deposit
-	if _, isV1 := events[*idx].Data["msg_index"]; isV1 {
-		*idx += 1
+	if _, isV1 := event.Data["msg_index"]; isV1 {
+		c.Skip(1)
 	} else {
-		*idx += 2
+		c.Skip(2)
 	}
 
-	if len(events) > *idx {
-		if events[*idx].Type == types.EventTypeSubmitProposal {
+	if event, ok := c.Peek(); ok {
+		if event.Type == types.EventTypeSubmitProposal {
 			msg.Proposal.Status = types.ProposalStatusActive
 			msg.Proposal.ActivationTime = &ctx.Block.Time
 		}

--- a/pkg/indexer/parser/events/submit_proposal_test.go
+++ b/pkg/indexer/parser/events/submit_proposal_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -17,11 +16,12 @@ import (
 func Test_handleSubmitProposal(t *testing.T) {
 	ts := time.Now()
 	tests := []struct {
-		name     string
-		ctx      *context.Context
-		events   []storage.Event
-		msg      *storage.Message
-		idx      *int
+		name   string
+		ctx    *context.Context
+		events []storage.Event
+		msg    *storage.Message
+		idx    int
+
 		proposal storage.Proposal
 	}{
 		{
@@ -98,7 +98,8 @@ func Test_handleSubmitProposal(t *testing.T) {
 					Status: types.ProposalStatusInactive,
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			proposal: storage.Proposal{
 				Id:             5,
 				ActivationTime: &ts,
@@ -173,7 +174,8 @@ func Test_handleSubmitProposal(t *testing.T) {
 					Status: types.ProposalStatusInactive,
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			proposal: storage.Proposal{
 				Id:      5,
 				Status:  types.ProposalStatusInactive,
@@ -255,7 +257,8 @@ func Test_handleSubmitProposal(t *testing.T) {
 					Status: types.ProposalStatusInactive,
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			proposal: storage.Proposal{
 				Id:      2,
 				Status:  types.ProposalStatusInactive,
@@ -341,7 +344,8 @@ func Test_handleSubmitProposal(t *testing.T) {
 				},
 				Time: ts,
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			proposal: storage.Proposal{
 				Id:             4,
 				Status:         types.ProposalStatusActive,
@@ -355,7 +359,9 @@ func Test_handleSubmitProposal(t *testing.T) {
 			tt.ctx.Block = &storage.Block{
 				Time: ts,
 			}
-			err := handleSubmitProposal(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			c.Skip(tt.idx)
+			err := handleSubmitProposal(tt.ctx, c, tt.msg)
 			require.NoError(t, err)
 			require.NotNil(t, tt.msg.Proposal)
 			require.Equal(t, tt.proposal, *tt.msg.Proposal)

--- a/pkg/indexer/parser/events/undelegation.go
+++ b/pkg/indexer/parser/events/undelegation.go
@@ -16,26 +16,28 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleUndelegate(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleUndelegate(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/cosmos.staking.v1beta1.MsgUndelegate" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/cosmos.staking.v1beta1.MsgUndelegate" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processUndelegate(ctx, events, msg, idx)
+	c.Next()
+	return processUndelegate(ctx, c, msg)
 }
 
-func processUndelegate(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
+func processUndelegate(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	first, _ := c.Peek()
 	var (
 		amount         = storageTypes.NumericZero()
 		validator      = storage.EmptyValidator()
 		completionTime = time.Now()
-		msgIdx         = decoder.StringFromMap(events[*idx].Data, "msg_index")
+		msgIdx         = decoder.StringFromMap(first.Data, "msg_index")
 		newFormat      = msgIdx != ""
 
 		undelegationEnd = func(event storage.Event, key string) error {
@@ -86,23 +88,22 @@ func processUndelegate(ctx *context.Context, events []storage.Event, msg *storag
 		}
 	)
 
-	for i := *idx; i < len(events); i++ {
-		switch events[i].Type {
+	for {
+		event, ok := c.Next()
+		if !ok {
+			return nil
+		}
+		switch event.Type {
 		case storageTypes.EventTypeMessage:
-			if module := decoder.StringFromMap(events[i].Data, "module"); module == storageTypes.ModuleNameStaking.String() {
-				if err := undelegationEnd(events[i], "sender"); err != nil {
-					return errors.Wrap(err, "undelegation end")
-				}
-
-				*idx = i + 1
-				return nil
+			if module := decoder.StringFromMap(event.Data, "module"); module == storageTypes.ModuleNameStaking.String() {
+				return errors.Wrap(undelegationEnd(event, "sender"), "undelegation end")
 			}
 		case storageTypes.EventTypeWithdrawRewards:
-			if err := parseWithdrawRewards(ctx, msg, events[i].Data); err != nil {
+			if err := parseWithdrawRewards(ctx, msg, event.Data); err != nil {
 				return err
 			}
 		case storageTypes.EventTypeUnbond:
-			unbond, err := decode.NewUnbond(events[i].Data)
+			unbond, err := decode.NewUnbond(event.Data)
 			if err != nil {
 				return err
 			}
@@ -130,13 +131,8 @@ func processUndelegate(ctx *context.Context, events []storage.Event, msg *storag
 			ctx.AddValidator(validator)
 
 			if newFormat {
-				if err := undelegationEnd(events[i], "delegator"); err != nil {
-					return errors.Wrap(err, "undelegation end")
-				}
-				*idx = i + 1
-				return nil
+				return errors.Wrap(undelegationEnd(event, "delegator"), "undelegation end")
 			}
 		}
 	}
-	return nil
 }

--- a/pkg/indexer/parser/events/undelegation_test.go
+++ b/pkg/indexer/parser/events/undelegation_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/celenium-io/celestia-indexer/internal/currency"
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -18,11 +17,12 @@ import (
 func Test_handleUndelegate(t *testing.T) {
 	ts := time.Now()
 	tests := []struct {
-		name         string
-		ctx          *context.Context
-		events       []storage.Event
-		msg          *storage.Message
-		idx          *int
+		name   string
+		ctx    *context.Context
+		events []storage.Event
+		msg    *storage.Message
+		idx    int
+
 		undelegation *storage.Undelegation
 	}{
 		{
@@ -141,7 +141,8 @@ func Test_handleUndelegate(t *testing.T) {
 					"ValidatorAddress": "celestiavaloper1uqj5ul7jtpskk9ste9mfv6jvh0y3w34vtpz3gw",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			undelegation: &storage.Undelegation{
 				Height:         844186,
 				Time:           ts,
@@ -261,7 +262,8 @@ func Test_handleUndelegate(t *testing.T) {
 					"ValidatorAddress": "celestiavaloper15urq2dtp9qce4fyc85m6upwm9xul3049gwdz0x",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			undelegation: &storage.Undelegation{
 				Height:         75,
 				Time:           ts,
@@ -383,7 +385,8 @@ func Test_handleUndelegate(t *testing.T) {
 					"ValidatorAddress": "celestiavaloper109nzhf6fvqvfan3tayzc8cywcsk6a5q45lmk5s",
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			undelegation: &storage.Undelegation{
 				Height:         75,
 				Time:           ts,
@@ -426,7 +429,9 @@ func Test_handleUndelegate(t *testing.T) {
 			tt.ctx.Block = &storage.Block{
 				Time: ts,
 			}
-			err := handleUndelegate(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			c.Skip(tt.idx)
+			err := handleUndelegate(tt.ctx, c, tt.msg)
 			require.NoError(t, err)
 			require.Len(t, tt.ctx.Undelegations, 1)
 			require.Equal(t, *tt.undelegation, tt.ctx.Undelegations[0])

--- a/pkg/indexer/parser/events/unjail.go
+++ b/pkg/indexer/parser/events/unjail.go
@@ -12,40 +12,42 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleUnjail(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleUnjail(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/cosmos.slashing.v1beta1.MsgUnjail" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/cosmos.slashing.v1beta1.MsgUnjail" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	return processUnjail(ctx, events, msg, idx)
+	return processUnjail(ctx, c, msg)
 }
 
-func processUnjail(ctx *context.Context, events []storage.Event, _ *storage.Message, idx *int) error {
-	if len(events) <= *idx {
+func processUnjail(ctx *context.Context, c *Cursor, _ *storage.Message) error {
+	event, ok := c.Next()
+	if !ok {
 		return errors.New("not enough events for unjail")
 	}
-	if events[*idx].Type != types.EventTypeMessage {
-		return errors.Errorf("slashing unexpected event type: %s", events[*idx].Type)
+	if event.Type != types.EventTypeMessage {
+		return errors.Errorf("slashing unexpected event type: %s", event.Type)
 	}
 
-	module := decoder.StringFromMap(events[*idx].Data, "module")
+	module := decoder.StringFromMap(event.Data, "module")
 	if module == "" {
-		*idx += 1
-		if len(events) <= *idx {
+		event, ok = c.Next()
+		if !ok {
 			return errors.New("not enough events for unjail after parsing module name")
 		}
-		module = decoder.StringFromMap(events[*idx].Data, "module")
+		module = decoder.StringFromMap(event.Data, "module")
 	}
 	if module != types.ModuleNameSlashing.String() {
 		return errors.Errorf("slashing unexpected module name: %s", module)
 	}
 
-	sender := decoder.StringFromMap(events[*idx].Data, "sender")
+	sender := decoder.StringFromMap(event.Data, "sender")
 	if sender == "" {
 		return errors.Errorf("slashing unexpected sender value: %s", sender)
 	}
@@ -71,6 +73,5 @@ func processUnjail(ctx *context.Context, events []storage.Event, _ *storage.Mess
 	v.Jailed = &jailed
 	ctx.AddValidator(v)
 
-	*idx += 1
 	return nil
 }

--- a/pkg/indexer/parser/events/unjail_test.go
+++ b/pkg/indexer/parser/events/unjail_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +18,7 @@ func Test_handleUnjail(t *testing.T) {
 		ctx    *context.Context
 		events []storage.Event
 		msg    *storage.Message
-		idx    *int
+		idx    int
 	}{
 		{
 			name: "test 1",
@@ -44,7 +43,7 @@ func Test_handleUnjail(t *testing.T) {
 				Type:   types.MsgUnjail,
 				Height: 844287,
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		}, {
 			name: "test 2",
 			ctx:  context.NewContext(),
@@ -64,12 +63,14 @@ func Test_handleUnjail(t *testing.T) {
 				Type:   types.MsgUnjail,
 				Height: 6758141,
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := handleUnjail(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			c.Skip(tt.idx)
+			err := handleUnjail(tt.ctx, c, tt.msg)
 			require.NoError(t, err)
 		})
 	}

--- a/pkg/indexer/parser/events/update_client.go
+++ b/pkg/indexer/parser/events/update_client.go
@@ -11,25 +11,27 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleUpdateClient(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleUpdateClient(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/ibc.core.client.v1.MsgUpdateClient" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/ibc.core.client.v1.MsgUpdateClient" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processUpdateClient(ctx, events, msg, idx)
+	c.Next()
+	return processUpdateClient(ctx, c, msg)
 }
 
-func processUpdateClient(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if len(events) <= *idx {
+func processUpdateClient(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	event, ok := c.Peek()
+	if !ok {
 		return errors.New("not enough events for update client")
 	}
-	uc, err := decode.NewUpdateClient(events[*idx].Data)
+	uc, err := decode.NewUpdateClient(event.Data)
 	if err != nil {
 		return errors.Wrap(err, "parse update client event")
 	}
@@ -48,6 +50,6 @@ func processUpdateClient(ctx *context.Context, events []storage.Event, msg *stor
 	}
 	ctx.AddIbcClient(ibcClient)
 
-	*idx += 2
+	c.Skip(2)
 	return nil
 }

--- a/pkg/indexer/parser/events/vote.go
+++ b/pkg/indexer/parser/events/vote.go
@@ -17,38 +17,40 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-func handleVote(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleVote(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	action := decoder.StringFromMap(events[*idx].Data, "action")
+	event, _ := c.Peek()
+	action := decoder.StringFromMap(event.Data, "action")
 	isValid := action == "/cosmos.gov.v1beta1.MsgVote" || action == "/cosmos.gov.v1.MsgVote" || action == "/cosmos.gov.v1.MsgVoteWeighted" || action == "/cosmos.gov.v1beta1.MsgVoteWeighted"
 	if !isValid {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processVote(ctx, events, msg, idx)
+	c.Next()
+	return processVote(ctx, c, msg)
 }
 
-func processVote(ctx *context.Context, events []storage.Event, _ *storage.Message, idx *int) error {
-	if len(events) <= *idx {
+func processVote(ctx *context.Context, c *Cursor, _ *storage.Message) error {
+	event, ok := c.Peek()
+	if !ok {
 		return errors.New("not enough events for vote")
 	}
-	if events[*idx].Type != types.EventTypeProposalVote {
-		return errors.Errorf("vote unexpected event type: %s", events[*idx].Type)
+	if event.Type != types.EventTypeProposalVote {
+		return errors.Errorf("vote unexpected event type: %s", event.Type)
 	}
 
-	proposalId, err := decoder.Uint64FromMap(events[*idx].Data, "proposal_id")
+	proposalId, err := decoder.Uint64FromMap(event.Data, "proposal_id")
 	if err != nil {
-		return errors.Errorf("vote can't receive proposal id: %##v", events[*idx].Data)
+		return errors.Errorf("vote can't receive proposal id: %##v", event.Data)
 	}
-	voter := decoder.StringFromMap(events[*idx].Data, "voter")
-	option := decoder.StringFromMap(events[*idx].Data, "option")
+	voter := decoder.StringFromMap(event.Data, "voter")
+	option := decoder.StringFromMap(event.Data, "option")
 
-	if err := parseOption(ctx, proposalId, voter, option, idx); err != nil {
+	if err := parseOption(ctx, proposalId, voter, option, c); err != nil {
 		return errors.Wrap(err, "parse option")
 	}
 
@@ -63,7 +65,7 @@ type optionType struct {
 	Weight decimal.Decimal `json:"weight"`
 }
 
-func parseOption(ctx *context.Context, proposalId uint64, voter, option string, idx *int) error {
+func parseOption(ctx *context.Context, proposalId uint64, voter, option string, c *Cursor) error {
 	var opts []optionType
 	if err := json.Unmarshal([]byte(option), &opts); err == nil {
 		if len(opts) == 0 {
@@ -100,7 +102,7 @@ func parseOption(ctx *context.Context, proposalId uint64, voter, option string, 
 
 			ctx.AddVote(&vote)
 		}
-		*idx += 1
+		c.Skip(1)
 		return nil
 	}
 
@@ -152,6 +154,6 @@ func parseOption(ctx *context.Context, proposalId uint64, voter, option string, 
 	}
 
 	ctx.AddVote(&vote)
-	*idx += 2
+	c.Skip(2)
 	return nil
 }

--- a/pkg/indexer/parser/events/vote_test.go
+++ b/pkg/indexer/parser/events/vote_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -21,8 +20,9 @@ func Test_handleVote(t *testing.T) {
 		ctx    *context.Context
 		events []storage.Event
 		msg    *storage.Message
-		idx    *int
-		votes  []*storage.Vote
+		idx    int
+
+		votes []*storage.Vote
 	}{
 		{
 			name: "vote test 1",
@@ -55,7 +55,8 @@ func Test_handleVote(t *testing.T) {
 				Type:   types.MsgVote,
 				Height: 3762606,
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			votes: []*storage.Vote{
 				{
 					ProposalId: 5,
@@ -103,7 +104,8 @@ func Test_handleVote(t *testing.T) {
 				Type:   types.MsgVoteWeighted,
 				Height: 871324,
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			votes: []*storage.Vote{
 				{
 					ProposalId: 3,
@@ -147,7 +149,8 @@ func Test_handleVote(t *testing.T) {
 				Type:   types.MsgVote,
 				Height: 871324,
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			votes: []*storage.Vote{
 				{
 					ProposalId: 4,
@@ -191,7 +194,8 @@ func Test_handleVote(t *testing.T) {
 				Type:   types.MsgVote,
 				Height: 871324,
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
+
 			votes: []*storage.Vote{
 				{
 					ProposalId: 4,
@@ -228,7 +232,9 @@ func Test_handleVote(t *testing.T) {
 				Time:   ts,
 				Height: tt.msg.Height,
 			}
-			err := handleVote(tt.ctx, tt.events, tt.msg, tt.idx)
+			c := NewCursor(tt.events)
+			c.Skip(tt.idx)
+			err := handleVote(tt.ctx, c, tt.msg)
 			require.NoError(t, err)
 			require.Len(t, tt.ctx.Votes, len(tt.votes))
 			require.Equal(t, tt.votes, tt.ctx.Votes)

--- a/pkg/indexer/parser/events/withdraw_reward_test.go
+++ b/pkg/indexer/parser/events/withdraw_reward_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +18,7 @@ func Test_handleWithdrawRewards(t *testing.T) {
 		ctx    *context.Context
 		events []storage.Event
 		msgs   []*storage.Message
-		idx    *int
+		idx    int
 	}{
 		{
 			name: "test 1",
@@ -51,7 +50,7 @@ func Test_handleWithdrawRewards(t *testing.T) {
 					Height: 848613,
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		}, {
 			name: "test 2",
 			ctx:  context.NewContext(),
@@ -85,13 +84,15 @@ func Test_handleWithdrawRewards(t *testing.T) {
 					Height: 848613,
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for i := range tt.msgs {
-				err := handleWithdrawDelegatorRewards(tt.ctx, tt.events, tt.msgs[i], tt.idx)
+				c := NewCursor(tt.events)
+				c.Skip(tt.idx)
+				err := handleWithdrawDelegatorRewards(tt.ctx, c, tt.msgs[i])
 				require.NoError(t, err)
 			}
 		})

--- a/pkg/indexer/parser/events/withdraw_rewards.go
+++ b/pkg/indexer/parser/events/withdraw_rewards.go
@@ -57,42 +57,45 @@ func parseWithdrawRewards(ctx *context.Context, msg *storage.Message, data map[s
 	return nil
 }
 
-func handleWithdrawDelegatorRewards(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleWithdrawDelegatorRewards(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	return processWithdrawDelegatorRewards(ctx, events, msg, idx)
+	return processWithdrawDelegatorRewards(ctx, c, msg)
 }
 
-func processWithdrawDelegatorRewards(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	msgIdx := decoder.StringFromMap(events[*idx].Data, "msg_index")
+func processWithdrawDelegatorRewards(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	first, _ := c.Peek()
+	msgIdx := decoder.StringFromMap(first.Data, "msg_index")
 	newFormat := msgIdx != ""
 
-	for i := *idx; i < len(events); i++ {
-		switch events[i].Type {
+	for {
+		event, ok := c.Next()
+		if !ok {
+			return nil
+		}
+		switch event.Type {
 		case storageTypes.EventTypeMessage:
 			if newFormat {
 				continue
 			}
-			if module := decoder.StringFromMap(events[i].Data, "module"); module == storageTypes.ModuleNameDistribution.String() {
-				*idx = i + 1
+			if module := decoder.StringFromMap(event.Data, "module"); module == storageTypes.ModuleNameDistribution.String() {
 				return nil
 			}
 		case storageTypes.EventTypeWithdrawRewards:
-			if err := parseWithdrawRewards(ctx, msg, events[i].Data); err != nil {
+			if err := parseWithdrawRewards(ctx, msg, event.Data); err != nil {
 				return err
 			}
 			if newFormat {
-				*idx = i + 1
 				return nil
 			}
 		}
 	}
-	return nil
 }

--- a/pkg/indexer/parser/events/withdraw_validator_commission.go
+++ b/pkg/indexer/parser/events/withdraw_validator_commission.go
@@ -15,20 +15,21 @@ import (
 
 const msgWithdrawValidatorCommission = "/cosmos.distribution.v1beta1.MsgWithdrawValidatorCommission"
 
-func handleWithdrawValidatorCommission(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleWithdrawValidatorCommission(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != msgWithdrawValidatorCommission {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != msgWithdrawValidatorCommission {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	return processWithdrawValidatorCommission(ctx, events, msg, idx)
+	return processWithdrawValidatorCommission(ctx, c, msg)
 }
 
-func processWithdrawValidatorCommission(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
+func processWithdrawValidatorCommission(ctx *context.Context, c *Cursor, msg *storage.Message) error {
 	var validator = storage.EmptyValidator()
 
 	if validatorAddress := msg.Data.GetStringOrDefault("ValidatorAddress"); validatorAddress != "" {
@@ -55,33 +56,41 @@ func processWithdrawValidatorCommission(ctx *context.Context, events []storage.E
 		return errors.Errorf("empty validator address in WithdrawValidatorCommission: %##v", msg.Data)
 	}
 
-	for ; *idx < len(events); *idx++ {
-		if events[*idx].Type == storageTypes.EventTypeWithdrawCommission {
-			commission, err := decode.NewWithdrawCommission(events[*idx].Data)
-			if err != nil {
-				return err
-			}
-			if commission.Amount == nil {
-				continue
-			}
-
-			amount, err := storageTypes.NumericFromString(commission.Amount.Amount.String())
-			if err != nil {
-				return errors.Wrap(err, "parse withdraw commission amount")
-			}
-			validator.Commissions = amount.Neg()
-
-			ctx.AddValidator(validator)
-
-			ctx.AddStakingLog(storage.StakingLog{
-				Height:    msg.Height,
-				Time:      msg.Time,
-				Validator: &validator,
-				Change:    amount.Neg().Copy(),
-				Type:      storageTypes.StakingLogTypeCommissions,
-			})
+	for {
+		event, ok := c.Peek()
+		if !ok {
 			break
 		}
+		if event.Type != storageTypes.EventTypeWithdrawCommission {
+			c.Next()
+			continue
+		}
+
+		commission, err := decode.NewWithdrawCommission(event.Data)
+		if err != nil {
+			return err
+		}
+		if commission.Amount == nil {
+			c.Next()
+			continue
+		}
+
+		amount, err := storageTypes.NumericFromString(commission.Amount.Amount.String())
+		if err != nil {
+			return errors.Wrap(err, "parse withdraw commission amount")
+		}
+		validator.Commissions = amount.Neg()
+
+		ctx.AddValidator(validator)
+
+		ctx.AddStakingLog(storage.StakingLog{
+			Height:    msg.Height,
+			Time:      msg.Time,
+			Validator: &validator,
+			Change:    amount.Neg().Copy(),
+			Type:      storageTypes.StakingLogTypeCommissions,
+		})
+		break
 	}
 	return nil
 }

--- a/pkg/indexer/parser/events/withdraw_validator_commission_test.go
+++ b/pkg/indexer/parser/events/withdraw_validator_commission_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/types"
-	testsuite "github.com/celenium-io/celestia-indexer/internal/test_suite"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +18,7 @@ func Test_handleWithdrawValidatorCommission(t *testing.T) {
 		ctx    *context.Context
 		events []storage.Event
 		msgs   []*storage.Message
-		idx    *int
+		idx    int
 	}{
 		{
 			name: "test 1",
@@ -83,7 +82,7 @@ func Test_handleWithdrawValidatorCommission(t *testing.T) {
 					},
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		}, {
 			name: "test 2",
 			ctx:  context.NewContext(),
@@ -142,7 +141,7 @@ func Test_handleWithdrawValidatorCommission(t *testing.T) {
 					},
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		}, {
 			name: "test 3",
 			ctx:  context.NewContext(),
@@ -206,13 +205,15 @@ func Test_handleWithdrawValidatorCommission(t *testing.T) {
 					},
 				},
 			},
-			idx: testsuite.Ptr(0),
+			idx: 0,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for i := range tt.msgs {
-				err := handleWithdrawValidatorCommission(tt.ctx, tt.events, tt.msgs[i], tt.idx)
+				c := NewCursor(tt.events)
+				c.Skip(tt.idx)
+				err := handleWithdrawValidatorCommission(tt.ctx, c, tt.msgs[i])
 				require.NoError(t, err)
 			}
 		})

--- a/pkg/indexer/parser/events/zkism.go
+++ b/pkg/indexer/parser/events/zkism.go
@@ -12,167 +12,155 @@ import (
 	"github.com/pkg/errors"
 )
 
-func handleCreateZkISM(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleCreateZkISM(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/celestia.zkism.v1.MsgCreateInterchainSecurityModule" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/celestia.zkism.v1.MsgCreateInterchainSecurityModule" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	return processCreateZkISM(ctx, events, msg, idx)
+	c.Next()
+	return processCreateZkISM(ctx, c, msg)
 }
 
-func processCreateZkISM(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	end := false
-	for !end {
-		if events[*idx].Type == types.EventTypeCelestiazkismv1EventCreateInterchainSecurityModule {
-			e, err := decode.NewZkISMCreateEvent(events[*idx].Data)
-			if err != nil {
-				return errors.Wrap(err, "parsing create zkism event")
-			}
-
-			ism := &storage.ZkISM{
-				Height:              ctx.Block.Height,
-				Time:                ctx.Block.Time,
-				ExternalId:          e.Id,
-				State:               e.State,
-				MerkleTreeAddress:   e.MerkleTreeAddress,
-				Groth16VKey:         e.Groth16VKey,
-				StateTransitionVKey: e.StateTransitionVKey,
-				StateMembershipVKey: e.StateMembershipVKey,
-				TxId:                msg.TxId,
-			}
-			if e.Creator != "" {
-				ism.Creator = &storage.Address{Address: e.Creator}
-			}
-
-			ctx.AddZkISM(ism)
-			end = true
+func processCreateZkISM(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	for event := range c.MsgEvents("action") {
+		if event.Type != types.EventTypeCelestiazkismv1EventCreateInterchainSecurityModule {
+			continue
 		}
 
-		action := decoder.StringFromMap(events[*idx].Data, "action")
-		end = len(events)-1 == *idx || action != "" || end
-		*idx += 1
+		e, err := decode.NewZkISMCreateEvent(event.Data)
+		if err != nil {
+			return errors.Wrap(err, "parsing create zkism event")
+		}
+
+		ism := &storage.ZkISM{
+			Height:              ctx.Block.Height,
+			Time:                ctx.Block.Time,
+			ExternalId:          e.Id,
+			State:               e.State,
+			MerkleTreeAddress:   e.MerkleTreeAddress,
+			Groth16VKey:         e.Groth16VKey,
+			StateTransitionVKey: e.StateTransitionVKey,
+			StateMembershipVKey: e.StateMembershipVKey,
+			TxId:                msg.TxId,
+		}
+		if e.Creator != "" {
+			ism.Creator = &storage.Address{Address: e.Creator}
+		}
+
+		ctx.AddZkISM(ism)
+		break
 	}
 	return nil
 }
 
-func handleUpdateZkISM(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
+func handleUpdateZkISM(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
 	}
 	if msg == nil {
 		return errors.New("nil message in events handler")
 	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/celestia.zkism.v1.MsgUpdateInterchainSecurityModule" {
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/celestia.zkism.v1.MsgUpdateInterchainSecurityModule" {
 		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
 	}
-	*idx += 1
-	if err := processUpdateZkISM(ctx, events, msg, idx); err != nil {
-		return err
+	c.Next()
+	return processUpdateZkISM(ctx, c, msg)
+}
+
+func processUpdateZkISM(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	for event := range c.MsgEvents("action") {
+		if event.Type != types.EventTypeCelestiazkismv1EventUpdateInterchainSecurityModule {
+			continue
+		}
+
+		e, err := decode.NewZkISMUpdateEvent(event.Data)
+		if err != nil {
+			return errors.Wrap(err, "parsing update zkism event")
+		}
+
+		var addr *storage.Address
+		if signer := msg.Data.GetStringOrDefault("Signer"); signer != "" {
+			addr = &storage.Address{
+				Address:    signer,
+				Height:     msg.Height,
+				LastHeight: msg.Height,
+				Balances:   []storage.Balance{storage.EmptyBalance()},
+			}
+		}
+
+		ctx.AddZkISM(&storage.ZkISM{
+			ExternalId: e.Id,
+			State:      e.NewState,
+		})
+		ctx.AddZkIsmUpdate(&storage.ZkISMUpdate{
+			Height:          ctx.Block.Height,
+			Time:            ctx.Block.Time,
+			NewState:        e.NewState,
+			TxId:            msg.TxId,
+			ZkISMExternalId: e.Id,
+			Signer:          addr,
+		})
+		break
 	}
 	return nil
 }
 
-func processUpdateZkISM(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	end := false
-	for !end {
-		if events[*idx].Type == types.EventTypeCelestiazkismv1EventUpdateInterchainSecurityModule {
-			e, err := decode.NewZkISMUpdateEvent(events[*idx].Data)
-			if err != nil {
-				return errors.Wrap(err, "parsing update zkism event")
-			}
+func handleSubmitZkISMMessages(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	if c == nil {
+		return errors.New("nil event cursor")
+	}
+	if msg == nil {
+		return errors.New("nil message in events handler")
+	}
+	event, _ := c.Peek()
+	if action := decoder.StringFromMap(event.Data, "action"); action != "/celestia.zkism.v1.MsgSubmitMessages" {
+		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
+	}
+	c.Next()
+	return processSubmitZkISMMessages(ctx, c, msg)
+}
 
-			var addr *storage.Address
-			if signer := msg.Data.GetStringOrDefault("Signer"); signer != "" {
-				addr = &storage.Address{
-					Address:    signer,
-					Height:     msg.Height,
-					LastHeight: msg.Height,
-					Balances:   []storage.Balance{storage.EmptyBalance()},
-				}
-			}
+func processSubmitZkISMMessages(ctx *context.Context, c *Cursor, msg *storage.Message) error {
+	for event := range c.MsgEvents("action") {
+		if event.Type != types.EventTypeCelestiazkismv1EventSubmitMessages {
+			continue
+		}
 
-			ctx.AddZkISM(&storage.ZkISM{
-				ExternalId: e.Id,
-				State:      e.NewState,
-			})
-			ctx.AddZkIsmUpdate(&storage.ZkISMUpdate{
+		e, err := decode.NewZkISMSubmitMessagesEvent(event.Data)
+		if err != nil {
+			return errors.Wrap(err, "parsing submit zkism messages event")
+		}
+
+		var addr *storage.Address
+		if signer := msg.Data.GetStringOrDefault("Signer"); signer != "" {
+			addr = &storage.Address{
+				Address:    signer,
+				Height:     msg.Height,
+				LastHeight: msg.Height,
+				Balances:   []storage.Balance{storage.EmptyBalance()},
+			}
+		}
+
+		for i := range e.MessageIds {
+			ctx.AddZkIsmMessage(&storage.ZkISMMessage{
 				Height:          ctx.Block.Height,
 				Time:            ctx.Block.Time,
-				NewState:        e.NewState,
+				StateRoot:       e.StateRoot,
+				MessageId:       e.MessageIds[i],
 				TxId:            msg.TxId,
-				ZkISMExternalId: e.Id,
 				Signer:          addr,
+				ZkISMExternalId: e.Id,
 			})
-			end = true
 		}
 
-		action := decoder.StringFromMap(events[*idx].Data, "action")
-		end = len(events)-1 == *idx || action != "" || end
-		*idx += 1
-	}
-	return nil
-}
-
-func handleSubmitZkISMMessages(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	if idx == nil {
-		return errors.New("nil event index")
-	}
-	if msg == nil {
-		return errors.New("nil message in events handler")
-	}
-	if action := decoder.StringFromMap(events[*idx].Data, "action"); action != "/celestia.zkism.v1.MsgSubmitMessages" {
-		return errors.Errorf("unexpected event action %s for message type %s", action, msg.Type.String())
-	}
-	*idx += 1
-	if err := processSubmitZkISMMessages(ctx, events, msg, idx); err != nil {
-		return err
-	}
-	return nil
-}
-
-func processSubmitZkISMMessages(ctx *context.Context, events []storage.Event, msg *storage.Message, idx *int) error {
-	end := false
-	for !end {
-		if events[*idx].Type == types.EventTypeCelestiazkismv1EventSubmitMessages {
-			e, err := decode.NewZkISMSubmitMessagesEvent(events[*idx].Data)
-			if err != nil {
-				return errors.Wrap(err, "parsing submit zkism messages event")
-			}
-
-			var addr *storage.Address
-			if signer := msg.Data.GetStringOrDefault("Signer"); signer != "" {
-				addr = &storage.Address{
-					Address:    signer,
-					Height:     msg.Height,
-					LastHeight: msg.Height,
-					Balances:   []storage.Balance{storage.EmptyBalance()},
-				}
-			}
-
-			for i := range e.MessageIds {
-				ctx.AddZkIsmMessage(&storage.ZkISMMessage{
-					Height:          ctx.Block.Height,
-					Time:            ctx.Block.Time,
-					StateRoot:       e.StateRoot,
-					MessageId:       e.MessageIds[i],
-					TxId:            msg.TxId,
-					Signer:          addr,
-					ZkISMExternalId: e.Id,
-				})
-			}
-
-			end = true
-		}
-
-		action := decoder.StringFromMap(events[*idx].Data, "action")
-		end = len(events)-1 == *idx || action != "" || end
-		*idx += 1
+		break
 	}
 	return nil
 }

--- a/pkg/indexer/parser/events/zkism_test.go
+++ b/pkg/indexer/parser/events/zkism_test.go
@@ -28,25 +28,24 @@ func makeZkISMContext() *context.Context {
 // handleCreateZkISM
 // ──────────────────────────────────────────────────────────
 
-func Test_handleCreateZkISM_NilIndex(t *testing.T) {
+func Test_handleCreateZkISM_NilCursor(t *testing.T) {
 	ctx := makeZkISMContext()
 	msg := &storage.Message{Type: types.MsgCreateInterchainSecurityModule}
-	err := handleCreateZkISM(ctx, nil, msg, nil)
+	err := handleCreateZkISM(ctx, nil, msg)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "nil event index")
+	require.Contains(t, err.Error(), "nil event cursor")
 }
 
 func Test_handleCreateZkISM_NilMessage(t *testing.T) {
 	ctx := makeZkISMContext()
-	idx := 0
-	err := handleCreateZkISM(ctx, nil, nil, &idx)
+	c := NewCursor(nil)
+	err := handleCreateZkISM(ctx, c, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "nil message")
 }
 
 func Test_handleCreateZkISM_WrongAction(t *testing.T) {
 	ctx := makeZkISMContext()
-	idx := 0
 	msg := &storage.Message{Type: types.MsgCreateInterchainSecurityModule}
 	events := []storage.Event{
 		{
@@ -57,7 +56,8 @@ func Test_handleCreateZkISM_WrongAction(t *testing.T) {
 			},
 		},
 	}
-	err := handleCreateZkISM(ctx, events, msg, &idx)
+	c := NewCursor(events)
+	err := handleCreateZkISM(ctx, c, msg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected event action")
 }
@@ -72,7 +72,6 @@ func Test_handleCreateZkISM_Success(t *testing.T) {
 	toHex := func(b []byte) string { return "0x" + hex.EncodeToString(b) }
 
 	ctx := makeZkISMContext()
-	idx := 0
 	msg := &storage.Message{Type: types.MsgCreateInterchainSecurityModule}
 	events := []storage.Event{
 		{
@@ -98,7 +97,8 @@ func Test_handleCreateZkISM_Success(t *testing.T) {
 		},
 	}
 
-	err := handleCreateZkISM(ctx, events, msg, &idx)
+	c := NewCursor(events)
+	err := handleCreateZkISM(ctx, c, msg)
 	require.NoError(t, err)
 	require.NotEmpty(t, ctx.ZkISMs.Len())
 	ism, ok := ctx.ZkISMs.Get("42")
@@ -130,7 +130,6 @@ func Test_handleCreateZkISM_StopsAtNextAction(t *testing.T) {
 	toHex := func(b []byte) string { return "0x" + hex.EncodeToString(b) }
 
 	ctx := makeZkISMContext()
-	idx := testsuite.Ptr(0)
 	events := []storage.Event{
 		{
 			Type: "message",
@@ -162,37 +161,40 @@ func Test_handleCreateZkISM_StopsAtNextAction(t *testing.T) {
 	}
 
 	msg := &storage.Message{Type: types.MsgCreateInterchainSecurityModule}
-	err := handleCreateZkISM(ctx, events, msg, idx)
+	c := NewCursor(events)
+	err := handleCreateZkISM(ctx, c, msg)
 	require.NoError(t, err)
 	require.NotEmpty(t, ctx.ZkISMs.Len())
 	_, ok := ctx.ZkISMs.Get("01")
 	require.True(t, ok)
-	require.Equal(t, 2, *idx, "index must stop before the next action event")
+
+	next, ok := c.Peek()
+	require.True(t, ok, "cursor must stop before the next action event")
+	require.Equal(t, "/celestia.zkism.v1.MsgUpdateInterchainSecurityModule", next.Data["action"])
 }
 
 // ──────────────────────────────────────────────────────────
 // handleUpdateZkISM
 // ──────────────────────────────────────────────────────────
 
-func Test_handleUpdateZkISM_NilIndex(t *testing.T) {
+func Test_handleUpdateZkISM_NilCursor(t *testing.T) {
 	ctx := makeZkISMContext()
 	msg := &storage.Message{Type: types.MsgUpdateInterchainSecurityModule}
-	err := handleUpdateZkISM(ctx, nil, msg, nil)
+	err := handleUpdateZkISM(ctx, nil, msg)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "nil event index")
+	require.Contains(t, err.Error(), "nil event cursor")
 }
 
 func Test_handleUpdateZkISM_NilMessage(t *testing.T) {
 	ctx := makeZkISMContext()
-	idx := 0
-	err := handleUpdateZkISM(ctx, nil, nil, &idx)
+	c := NewCursor(nil)
+	err := handleUpdateZkISM(ctx, c, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "nil message")
 }
 
 func Test_handleUpdateZkISM_WrongAction(t *testing.T) {
 	ctx := makeZkISMContext()
-	idx := 0
 	msg := &storage.Message{Type: types.MsgUpdateInterchainSecurityModule}
 	events := []storage.Event{
 		{
@@ -200,7 +202,8 @@ func Test_handleUpdateZkISM_WrongAction(t *testing.T) {
 			Data: map[string]string{"action": "/cosmos.bank.v1beta1.MsgSend"},
 		},
 	}
-	err := handleUpdateZkISM(ctx, events, msg, &idx)
+	c := NewCursor(events)
+	err := handleUpdateZkISM(ctx, c, msg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected event action")
 }
@@ -210,7 +213,6 @@ func Test_handleUpdateZkISM_Success(t *testing.T) {
 	toHex := func(b []byte) string { return "0x" + hex.EncodeToString(b) }
 
 	ctx := makeZkISMContext()
-	idx := 0
 	msg := &storage.Message{
 		Type: types.MsgUpdateInterchainSecurityModule,
 		Data: map[string]any{
@@ -234,7 +236,8 @@ func Test_handleUpdateZkISM_Success(t *testing.T) {
 		},
 	}
 
-	err := handleUpdateZkISM(ctx, events, msg, &idx)
+	c := NewCursor(events)
+	err := handleUpdateZkISM(ctx, c, msg)
 	require.NoError(t, err)
 	require.NotEmpty(t, ctx.ZkIsmUpdates)
 
@@ -257,7 +260,6 @@ func Test_handleUpdateZkISM_UpdatesContextState(t *testing.T) {
 	// Simulate ISM created earlier in this block
 	ctx.ZkISMs.Set("0x07", &storage.ZkISM{ExternalId: testsuite.MustHexDecode("07"), State: oldState})
 
-	idx := 0
 	msg := &storage.Message{Type: types.MsgUpdateInterchainSecurityModule}
 	events := []storage.Event{
 		{
@@ -276,7 +278,8 @@ func Test_handleUpdateZkISM_UpdatesContextState(t *testing.T) {
 		},
 	}
 
-	err := handleUpdateZkISM(ctx, events, msg, &idx)
+	c := NewCursor(events)
+	err := handleUpdateZkISM(ctx, c, msg)
 	require.NoError(t, err)
 
 	stored, ok := ctx.ZkISMs.Get("07")
@@ -288,25 +291,24 @@ func Test_handleUpdateZkISM_UpdatesContextState(t *testing.T) {
 // handleSubmitZkISMMessages
 // ──────────────────────────────────────────────────────────
 
-func Test_handleSubmitZkISMMessages_NilIndex(t *testing.T) {
+func Test_handleSubmitZkISMMessages_NilCursor(t *testing.T) {
 	ctx := makeZkISMContext()
 	msg := &storage.Message{Type: types.MsgSubmitMessages}
-	err := handleSubmitZkISMMessages(ctx, nil, msg, nil)
+	err := handleSubmitZkISMMessages(ctx, nil, msg)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "nil event index")
+	require.Contains(t, err.Error(), "nil event cursor")
 }
 
 func Test_handleSubmitZkISMMessages_NilMessage(t *testing.T) {
 	ctx := makeZkISMContext()
-	idx := 0
-	err := handleSubmitZkISMMessages(ctx, nil, nil, &idx)
+	c := NewCursor(nil)
+	err := handleSubmitZkISMMessages(ctx, c, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "nil message")
 }
 
 func Test_handleSubmitZkISMMessages_WrongAction(t *testing.T) {
 	ctx := makeZkISMContext()
-	idx := 0
 	msg := &storage.Message{Type: types.MsgSubmitMessages}
 	events := []storage.Event{
 		{
@@ -314,7 +316,8 @@ func Test_handleSubmitZkISMMessages_WrongAction(t *testing.T) {
 			Data: map[string]string{"action": "/cosmos.bank.v1beta1.MsgSend"},
 		},
 	}
-	err := handleSubmitZkISMMessages(ctx, events, msg, &idx)
+	c := NewCursor(events)
+	err := handleSubmitZkISMMessages(ctx, c, msg)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected event action")
 }
@@ -325,7 +328,6 @@ func Test_handleSubmitZkISMMessages_SingleMessage(t *testing.T) {
 	toHex := func(b []byte) string { return "\"0x" + hex.EncodeToString(b) + "\"" }
 
 	ctx := makeZkISMContext()
-	idx := 0
 	msg := &storage.Message{
 		Type: types.MsgSubmitMessages,
 		Data: map[string]any{
@@ -350,7 +352,8 @@ func Test_handleSubmitZkISMMessages_SingleMessage(t *testing.T) {
 		},
 	}
 
-	err := handleSubmitZkISMMessages(ctx, events, msg, &idx)
+	c := NewCursor(events)
+	err := handleSubmitZkISMMessages(ctx, c, msg)
 	require.NoError(t, err)
 	require.Len(t, ctx.ZkIsmMessages, 1)
 
@@ -366,7 +369,6 @@ func Test_handleSubmitZkISMMessages_SingleMessage(t *testing.T) {
 
 func Test_handleSubmitZkISMMessages_Real(t *testing.T) {
 	ctx := makeZkISMContext()
-	idx := 0
 	msg := &storage.Message{
 		Type: types.MsgSubmitMessages,
 		Data: map[string]any{
@@ -394,7 +396,8 @@ func Test_handleSubmitZkISMMessages_Real(t *testing.T) {
 		},
 	}
 
-	err := handleSubmitZkISMMessages(ctx, events, msg, &idx)
+	c := NewCursor(events)
+	err := handleSubmitZkISMMessages(ctx, c, msg)
 	require.NoError(t, err)
 	require.Len(t, ctx.ZkIsmMessages, 1)
 
@@ -416,7 +419,6 @@ func Test_handleSubmitZkISMMessages_MultipleMessages(t *testing.T) {
 	toHex := func(b []byte) string { return "\"0x" + hex.EncodeToString(b) + "\"" }
 
 	ctx := makeZkISMContext()
-	idx := 0
 	msg := &storage.Message{
 		Type: types.MsgSubmitMessages,
 		Data: map[string]any{
@@ -441,7 +443,8 @@ func Test_handleSubmitZkISMMessages_MultipleMessages(t *testing.T) {
 		},
 	}
 
-	err := handleSubmitZkISMMessages(ctx, events, msg, &idx)
+	c := NewCursor(events)
+	err := handleSubmitZkISMMessages(ctx, c, msg)
 	require.NoError(t, err)
 	require.Len(t, ctx.ZkIsmMessages, 3)
 
@@ -463,7 +466,6 @@ func Test_handleSubmitZkISMMessages_SequentialMessages(t *testing.T) {
 	toHex := func(b []byte) string { return "\"0x" + hex.EncodeToString(b) + "\"" }
 
 	ctx := makeZkISMContext()
-	idx := testsuite.Ptr(0)
 	events := []storage.Event{
 		{
 			Type: "message",
@@ -502,8 +504,9 @@ func Test_handleSubmitZkISMMessages_SequentialMessages(t *testing.T) {
 		{Type: types.MsgSubmitMessages},
 	}
 
+	c := NewCursor(events)
 	for i := range msgs {
-		err := handleSubmitZkISMMessages(ctx, events, msgs[i], idx)
+		err := handleSubmitZkISMMessages(ctx, c, msgs[i])
 		require.NoError(t, err)
 	}
 

--- a/pkg/indexer/parser/parseTxs.go
+++ b/pkg/indexer/parser/parseTxs.go
@@ -11,7 +11,6 @@ import (
 	storageTypes "github.com/celenium-io/celestia-indexer/internal/storage/types"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
-	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/decoder"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/parser/events"
 	"github.com/celenium-io/celestia-indexer/pkg/types"
 	"github.com/pkg/errors"
@@ -89,18 +88,8 @@ func (p *Module) parseTx(ctx *context.Context, b *types.BlockData, index int, tx
 
 	ctx.TxEventsCount += int(t.EventsCount)
 
-	var eventsIdx int
-
-	// find first action
-	for i := range txEvents {
-		if txEvents[i].Type != storageTypes.EventTypeMessage {
-			continue
-		}
-		if action := decoder.StringFromMap(txEvents[i].Data, "action"); action != "" {
-			eventsIdx = i
-			break
-		}
-	}
+	c := events.NewCursor(txEvents)
+	c.SkipToNext("action")
 
 	for i := range d.Messages {
 		dm, err := decode.Message(ctx, d.Messages[i], i, t.Status, t.Id)
@@ -125,7 +114,7 @@ func (p *Module) parseTx(ctx *context.Context, b *types.BlockData, index int, tx
 		t.BlobsCount += len(dm.BlobLogs)
 
 		if !txRes.IsFailed() {
-			if err := events.Handle(ctx, txEvents, &dm.Msg, &eventsIdx); err != nil {
+			if err := events.Handle(ctx, c, &dm.Msg); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Replaces the manually-threaded `eventsIdx int` pointer (passed by reference through every message event handler) with a dedicated `Cursor` type (`pkg/indexer/parser/events/cursor.go`) that owns event traversal and boundary detection.

- `Cursor` provides `Peek`, `Next`, `Skip`, `MsgEvents` (an iterator that yields events up to the next boundary), `SkipToNext`, and `Remaining`, centralizing the "stop key" boundary logic (`action` for top-level messages, `module` for IBC-nested ones) that was previously duplicated across handlers.
- All per-message/per-module event handlers (delegate, redelegate, undelegate, IBC channel/connection/client events, Hyperlane mailbox/token/transfer events, zkISM, governance, etc.) updated to take `*Cursor` instead of `(events []storage.Event, idx *int)`.
- `parseTx` simplified to build one `Cursor` per transaction and pass it through, instead of computing/mutating a raw index.
- No behavioral change intended — same boundary semantics, just encapsulated; covered by existing handler tests plus new `cursor_test.go` and `cursor_golden_test.go`.