### PR TITLE
Refactor: use iterator for ChainStore.All()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ adr:
 	@cp adr/adr-template.md adr/adr-$(NUM)-$(TITLE).md
 
 generate:
-	go generate -v ./internal/blob ./internal/storage ./internal/storage/types ./pkg/node ./cmd/api/gas
+	go generate -v ./internal/blob ./internal/storage ./internal/storage/types ./pkg/node ./cmd/api/gas ./cmd/api/hyperlane
 
 api-docs:
 	cd cmd/api && swag init --md markdown -parseDependency --parseInternal --parseDepth 1 --outputTypes json

--- a/cmd/api/handler/hyperlane.go
+++ b/cmd/api/handler/hyperlane.go
@@ -436,11 +436,9 @@ func (handler *HyperlaneHandler) GetTransfer(c echo.Context) error {
 //	@Failure		500	{object}	Error
 //	@Router			/hyperlane/domains [get]
 func (handler *HyperlaneHandler) ListDomains(c echo.Context) error {
-	data := handler.chainStore.All()
-
-	response := make(map[uint64]*responses.DomainMetadata, len(data))
-	for i := range data {
-		response[i] = responses.NewDomainMetadata(data[i].DomainId, handler.chainStore)
+	response := make(map[uint64]*responses.DomainMetadata)
+	for id, item := range handler.chainStore.All() {
+		response[id] = responses.NewDomainMetadata(id, item)
 	}
 
 	return c.JSON(http.StatusOK, response)

--- a/cmd/api/handler/hyperlane_test.go
+++ b/cmd/api/handler/hyperlane_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -662,13 +663,8 @@ func (s *HyperlaneTestSuite) TestListDomains() {
 
 	s.chainStore.EXPECT().
 		All().
-		Return(testChainStore).
+		Return(maps.All(testChainStore)).
 		Times(1)
-
-	s.chainStore.EXPECT().
-		Get(gomock.Any()).
-		Return(testChainMetadata, true).
-		Times(len(testChainStore))
 
 	s.chainStore.Set(testChainStore)
 	s.Require().NoError(s.handler.ListDomains(c))

--- a/cmd/api/handler/responses/hyperlane.go
+++ b/cmd/api/handler/responses/hyperlane.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/cmd/api/hyperlane"
 	"github.com/celenium-io/celestia-indexer/internal/storage"
+	pkgHyperlane "github.com/celenium-io/celestia-indexer/pkg/node/hyperlane"
 	pkgTypes "github.com/celenium-io/celestia-indexer/pkg/types"
 )
 
@@ -230,25 +231,21 @@ type DomainMetadata struct {
 	NativeToken    NativeToken     `json:"native_token"`
 }
 
-func NewDomainMetadata(domainId uint64, store hyperlane.IChainStore) *DomainMetadata {
-	if metadata, ok := store.Get(domainId); ok {
-		explorers := make([]BlockExplorer, len(metadata.BlockExplorers))
-		for i := range explorers {
-			explorers[i] = BlockExplorer(metadata.BlockExplorers[i])
-		}
-		return &DomainMetadata{
-			Domain:         domainId,
-			Name:           metadata.DisplayName,
-			BlockExplorers: explorers,
-			NativeToken: NativeToken{
-				Decimals: metadata.NativeToken.Decimals,
-				Name:     metadata.NativeToken.Name,
-				Symbol:   metadata.NativeToken.Symbol,
-			},
-		}
+func NewDomainMetadata(domainId uint64, metadata pkgHyperlane.ChainMetadata) *DomainMetadata {
+	explorers := make([]BlockExplorer, len(metadata.BlockExplorers))
+	for i := range explorers {
+		explorers[i] = BlockExplorer(metadata.BlockExplorers[i])
 	}
-
-	return nil
+	return &DomainMetadata{
+		Domain:         domainId,
+		Name:           metadata.DisplayName,
+		BlockExplorers: explorers,
+		NativeToken: NativeToken{
+			Decimals: metadata.NativeToken.Decimals,
+			Name:     metadata.NativeToken.Name,
+			Symbol:   metadata.NativeToken.Symbol,
+		},
+	}
 }
 
 type HlDomainStats struct {

--- a/cmd/api/handler/stats_test.go
+++ b/cmd/api/handler/stats_test.go
@@ -693,11 +693,6 @@ func (s *StatsTestSuite) TestHlDomainStats() {
 		Times(1)
 
 	s.chainStore.EXPECT().
-		All().
-		Return(testChainStore).
-		Times(1)
-
-	s.chainStore.EXPECT().
 		Get(gomock.Any()).
 		Return(testChainMetadata, true).
 		Times(len(testChainStore))
@@ -713,7 +708,6 @@ func (s *StatsTestSuite) TestHlDomainStats() {
 		}, nil)
 
 	s.chainStore.Set(testChainStore)
-	s.chainStore.All()
 	s.Require().NoError(s.handler.HlByDomain(c))
 	s.Require().Equal(http.StatusOK, rec.Code)
 

--- a/cmd/api/hyperlane/chain_store.go
+++ b/cmd/api/hyperlane/chain_store.go
@@ -5,6 +5,7 @@ package hyperlane
 
 import (
 	"context"
+	"iter"
 	"sync"
 	"time"
 
@@ -56,15 +57,20 @@ func (cs *ChainStore) Set(metadata map[uint64]hyperlane.ChainMetadata) {
 	cs.mx.Unlock()
 }
 
-func (cs *ChainStore) All() map[uint64]hyperlane.ChainMetadata {
-	cs.mx.RLock()
-	defer cs.mx.RUnlock()
-
-	s := make(map[uint64]hyperlane.ChainMetadata, len(cs.data))
-	for k, v := range cs.data {
-		s[k] = v
+// All returns an iterator over the stored chain metadata. The read lock is held
+// for the full iteration, so callers must not call Get/Set/All on the same store
+// from within the loop body — doing so recursively RLocks and can deadlock against
+// a pending Set() writer.
+func (cs *ChainStore) All() iter.Seq2[uint64, hyperlane.ChainMetadata] {
+	return func(yield func(uint64, hyperlane.ChainMetadata) bool) {
+		cs.mx.RLock()
+		defer cs.mx.RUnlock()
+		for k, v := range cs.data {
+			if !yield(k, v) {
+				return
+			}
+		}
 	}
-	return s
 }
 
 func (cs *ChainStore) sync(ctx context.Context) {

--- a/cmd/api/hyperlane/interface.go
+++ b/cmd/api/hyperlane/interface.go
@@ -6,6 +6,7 @@ package hyperlane
 import (
 	"context"
 	"io"
+	"iter"
 
 	"github.com/celenium-io/celestia-indexer/pkg/node/hyperlane"
 )
@@ -17,5 +18,5 @@ type IChainStore interface {
 	Start(ctx context.Context)
 	Get(domainId uint64) (hyperlane.ChainMetadata, bool)
 	Set(metadata map[uint64]hyperlane.ChainMetadata)
-	All() map[uint64]hyperlane.ChainMetadata
+	All() iter.Seq2[uint64, hyperlane.ChainMetadata]
 }

--- a/cmd/api/hyperlane/mock.go
+++ b/cmd/api/hyperlane/mock.go
@@ -14,6 +14,7 @@ package hyperlane
 
 import (
 	context "context"
+	iter "iter"
 	reflect "reflect"
 
 	hyperlane "github.com/celenium-io/celestia-indexer/pkg/node/hyperlane"
@@ -45,10 +46,10 @@ func (m *MockIChainStore) EXPECT() *MockIChainStoreMockRecorder {
 }
 
 // All mocks base method.
-func (m *MockIChainStore) All() map[uint64]hyperlane.ChainMetadata {
+func (m *MockIChainStore) All() iter.Seq2[uint64, hyperlane.ChainMetadata] {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "All")
-	ret0, _ := ret[0].(map[uint64]hyperlane.ChainMetadata)
+	ret0, _ := ret[0].(iter.Seq2[uint64, hyperlane.ChainMetadata])
 	return ret0
 }
 
@@ -65,19 +66,19 @@ type MockIChainStoreAllCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockIChainStoreAllCall) Return(arg0 map[uint64]hyperlane.ChainMetadata) *MockIChainStoreAllCall {
+func (c *MockIChainStoreAllCall) Return(arg0 iter.Seq2[uint64, hyperlane.ChainMetadata]) *MockIChainStoreAllCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockIChainStoreAllCall) Do(f func() map[uint64]hyperlane.ChainMetadata) *MockIChainStoreAllCall {
+func (c *MockIChainStoreAllCall) Do(f func() iter.Seq2[uint64, hyperlane.ChainMetadata]) *MockIChainStoreAllCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockIChainStoreAllCall) DoAndReturn(f func() map[uint64]hyperlane.ChainMetadata) *MockIChainStoreAllCall {
+func (c *MockIChainStoreAllCall) DoAndReturn(f func() iter.Seq2[uint64, hyperlane.ChainMetadata]) *MockIChainStoreAllCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
## Summary
- `ChainStore.All()` now returns `iter.Seq2[uint64, hyperlane.ChainMetadata]`
  instead of a freshly copied `map[uint64]hyperlane.ChainMetadata`, avoiding
  an unnecessary allocation/copy of the whole map on every call while the
  read lock is held only for the duration of iteration.
- `ListDomains` was updated accordingly, and `NewDomainMetadata` now takes
  the `ChainMetadata` value directly instead of `(domainId, store)`. This
  also fixes a latent deadlock risk: the previous version called
  `store.Get()` from inside the `All()` iteration, which would recursively
  `RLock` the same `sync.RWMutex` and could deadlock against `Set()` (the
  24h metadata sync writer) if it landed mid-iteration.
- `IChainStore` interface and its mock were regenerated for the new
  signature; `make generate` now also covers `./cmd/api/hyperlane`.
- Tests updated to build the iterator via `maps.All(...)` and to drop the
  now-unused `Get()` mock expectations in `TestListDomains`.