### PR TITLE
Refactoring: improving tests

### DIFF
--- a/cmd/api/handler/address_test.go
+++ b/cmd/api/handler/address_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -86,8 +85,7 @@ func (s *AddressTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *AddressTestSuite) TearDownSuite() {
-	s.ctrl.Finish()
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteAddress_Run(t *testing.T) {
@@ -95,7 +93,7 @@ func TestSuiteAddress_Run(t *testing.T) {
 }
 
 func (s *AddressTestSuite) TestGet() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/:hash")
@@ -133,7 +131,7 @@ func (s *AddressTestSuite) TestGet() {
 }
 
 func (s *AddressTestSuite) TestGetInvalidAddress() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/:hash")
@@ -150,7 +148,7 @@ func (s *AddressTestSuite) TestGetInvalidAddress() {
 }
 
 func (s *AddressTestSuite) TestGetBadAddress() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/:hash")
@@ -167,7 +165,7 @@ func (s *AddressTestSuite) TestGetBadAddress() {
 }
 
 func (s *AddressTestSuite) TestList() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address")
@@ -227,7 +225,7 @@ func (s *AddressTestSuite) TestTransactions() {
 	q.Set("msg_type", "MsgSend")
 	q.Set("height", "1000")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/:hash/txs")
@@ -287,7 +285,7 @@ func (s *AddressTestSuite) TestMessages() {
 	q.Set("offset", "0")
 	q.Set("sort", "desc")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/:hash/messages")
@@ -347,7 +345,7 @@ func (s *AddressTestSuite) TestBlobs() {
 	q.Set("offset", "0")
 	q.Set("sort", "desc")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/:hash/blobs")
@@ -399,7 +397,7 @@ func (s *AddressTestSuite) TestBlobs() {
 }
 
 func (s *AddressTestSuite) TestCount() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/count")
@@ -423,7 +421,7 @@ func (s *AddressTestSuite) TestDelegations() {
 	q.Set("offset", "0")
 	q.Set("show_zero", "true")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/:hash/delegations")
@@ -470,7 +468,7 @@ func (s *AddressTestSuite) TestUndelegations() {
 	q.Set("limit", "10")
 	q.Set("offset", "0")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/:hash/undelegations")
@@ -523,7 +521,7 @@ func (s *AddressTestSuite) TestRedelegations() {
 	q.Set("limit", "10")
 	q.Set("offset", "0")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/:hash/redelegations")
@@ -580,7 +578,7 @@ func (s *AddressTestSuite) TestVestings() {
 	q.Set("limit", "10")
 	q.Set("offset", "0")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/:hash/vestings")
@@ -632,7 +630,7 @@ func (s *AddressTestSuite) TestGrants() {
 	q.Set("limit", "10")
 	q.Set("offset", "0")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/:hash/grants")
@@ -684,7 +682,7 @@ func (s *AddressTestSuite) TestGrantee() {
 	q.Set("limit", "10")
 	q.Set("offset", "0")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/:hash/grantee")
@@ -734,7 +732,7 @@ func (s *AddressTestSuite) TestGrantee() {
 func (s *AddressTestSuite) TestStats() {
 	for _, name := range []string{"tx_count", "fee", "gas_used", "gas_wanted"} {
 		for _, tf := range []string{"hour", "day", "month"} {
-			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 			rec := httptest.NewRecorder()
 			c := s.echo.NewContext(req, rec)
 			c.SetPath("/address/:hash/stats/:name/:timeframe")
@@ -776,7 +774,7 @@ func (s *AddressTestSuite) TestCelestials() {
 	q.Set("limit", "10")
 	q.Set("offset", "0")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/:hash/celestials")
@@ -821,7 +819,7 @@ func (s *AddressTestSuite) TestVotes() {
 	q.Set("limit", "10")
 	q.Set("offset", "0")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/:hash/votes")
@@ -887,7 +885,7 @@ func (s *AddressTestSuite) TestBalances() {
 	q.Set("limit", "10")
 	q.Set("offset", "0")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/:hash/balances")

--- a/cmd/api/handler/block_test.go
+++ b/cmd/api/handler/block_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
@@ -101,8 +100,7 @@ func (s *BlockTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *BlockTestSuite) TearDownSuite() {
-	s.ctrl.Finish()
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteBlock_Run(t *testing.T) {
@@ -110,7 +108,7 @@ func TestSuiteBlock_Run(t *testing.T) {
 }
 
 func (s *BlockTestSuite) TestGet() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/block/:height")
@@ -138,7 +136,7 @@ func (s *BlockTestSuite) TestGet() {
 }
 
 func (s *BlockTestSuite) TestGetNoContent() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/block/:height")
@@ -161,7 +159,7 @@ func (s *BlockTestSuite) TestGetWithoutStats() {
 	q := make(url.Values)
 	q.Set("stats", "false")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/block/:height")
@@ -192,7 +190,7 @@ func (s *BlockTestSuite) TestGetWithStats() {
 	q := make(url.Values)
 	q.Set("stats", "true")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/block/:height")
@@ -222,7 +220,7 @@ func (s *BlockTestSuite) TestGetWithStats() {
 }
 
 func (s *BlockTestSuite) TestGetInvalidBlockHeight() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/block/:height")
@@ -239,7 +237,7 @@ func (s *BlockTestSuite) TestGetInvalidBlockHeight() {
 }
 
 func (s *BlockTestSuite) TestList() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/block")
@@ -271,7 +269,7 @@ func (s *BlockTestSuite) TestListWithStats() {
 	q := make(url.Values)
 	q.Set("stats", "true")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/block")
@@ -304,7 +302,7 @@ func (s *BlockTestSuite) TestGetEvents() {
 	q.Set("limit", "2")
 	q.Set("offset", "0")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/block/:height/events")
@@ -348,7 +346,7 @@ func (s *BlockTestSuite) TestGetEvents() {
 }
 
 func (s *BlockTestSuite) TestGetStats() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/block/:height/stats")
@@ -371,7 +369,7 @@ func (s *BlockTestSuite) TestGetStats() {
 }
 
 func (s *BlockTestSuite) TestBlobs() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/block/:height/blobs")
@@ -413,7 +411,7 @@ func (s *BlockTestSuite) TestBlobs() {
 }
 
 func (s *BlockTestSuite) TestGetBlobsCount() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/block/:height/blobs/count")
@@ -437,7 +435,7 @@ func (s *BlockTestSuite) TestGetBlobsCount() {
 }
 
 func (s *BlockTestSuite) TestCount() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/address/count")
@@ -461,7 +459,7 @@ func (s *BlockTestSuite) TestGetMessages() {
 	q.Set("offset", "0")
 	q.Set("msg_type", "MsgSend")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/block/:height/messages")
@@ -525,7 +523,7 @@ func (s *BlockTestSuite) TestGetMessages() {
 }
 
 func (s *BlockTestSuite) TestBlockODS() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/block/:height/ods")
@@ -573,7 +571,7 @@ func (s *BlockTestSuite) TestBlockODS() {
 }
 
 func (s *BlockTestSuite) TestEmptyBlockODS() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/block/:height/ods")

--- a/cmd/api/handler/constant_test.go
+++ b/cmd/api/handler/constant_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -41,8 +40,7 @@ func (s *ConstantTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *ConstantTestSuite) TearDownSuite() {
-	s.ctrl.Finish()
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteConstant_Run(t *testing.T) {
@@ -50,7 +48,7 @@ func TestSuiteConstant_Run(t *testing.T) {
 }
 
 func (s *ConstantTestSuite) TestEnums() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/enums")

--- a/cmd/api/handler/forwarding_test.go
+++ b/cmd/api/handler/forwarding_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -72,7 +71,7 @@ func (s *ForwardingTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *ForwardingTestSuite) TearDownSuite() {
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteForwarding_Run(t *testing.T) {
@@ -85,7 +84,7 @@ func (s *ForwardingTestSuite) TestList() {
 	q.Set("offset", "0")
 	q.Set("sort", "desc")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/forwarding")
@@ -129,7 +128,7 @@ func (s *ForwardingTestSuite) TestList() {
 }
 
 func (s *ForwardingTestSuite) TestListDefaults() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/forwarding")
@@ -157,7 +156,7 @@ func (s *ForwardingTestSuite) TestListWithTxHash() {
 	q.Set("limit", "10")
 	q.Set("tx_hash", testTxHash)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/forwarding")
@@ -199,7 +198,7 @@ func (s *ForwardingTestSuite) TestListWithAddress() {
 	q.Set("limit", "10")
 	q.Set("address", testAddress)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/forwarding")
@@ -240,7 +239,7 @@ func (s *ForwardingTestSuite) TestListWithHeight() {
 	q.Set("limit", "10")
 	q.Set("height", "100")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/forwarding")
@@ -275,7 +274,7 @@ func (s *ForwardingTestSuite) TestListValidationError() {
 	q := make(url.Values)
 	q.Set("limit", "101")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/forwarding")
@@ -285,7 +284,7 @@ func (s *ForwardingTestSuite) TestListValidationError() {
 }
 
 func (s *ForwardingTestSuite) TestGet() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/forwarding/:id")
@@ -365,7 +364,7 @@ func (s *ForwardingTestSuite) TestGet() {
 }
 
 func (s *ForwardingTestSuite) TestGetValidationError() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/forwarding/:id")

--- a/cmd/api/handler/gas_test.go
+++ b/cmd/api/handler/gas_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -55,7 +54,7 @@ func (s *GasTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *GasTestSuite) TearDownSuite() {
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteGas_Run(t *testing.T) {
@@ -65,7 +64,7 @@ func TestSuiteGas_Run(t *testing.T) {
 func (s *GasTestSuite) TestEstimateForPfb() {
 	q := make(url.Values)
 	q.Set("sizes", "12,34")
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/gas/estimate_for_pfb")
@@ -101,7 +100,7 @@ func (s *GasTestSuite) TestEstimateForPfbWithVersions() {
 	q := make(url.Values)
 	q.Set("sizes", "12,34")
 	q.Set("versions", "0,1")
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/gas/estimate_for_pfb")
@@ -137,7 +136,7 @@ func (s *GasTestSuite) TestEstimateForPfbWithInvalidVersion() {
 	q := make(url.Values)
 	q.Set("sizes", "12,34")
 	q.Set("versions", "0,132")
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/gas/estimate_for_pfb")
@@ -150,7 +149,7 @@ func (s *GasTestSuite) TestEstimateForPfbWithInvalidVersionLen() {
 	q := make(url.Values)
 	q.Set("sizes", "12,34")
 	q.Set("versions", "0")
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/gas/estimate_for_pfb")
@@ -160,7 +159,7 @@ func (s *GasTestSuite) TestEstimateForPfbWithInvalidVersionLen() {
 }
 
 func (s *GasTestSuite) TestEstimatePrice() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/gas/price")
@@ -183,7 +182,7 @@ func (s *GasTestSuite) TestEstimatePrice() {
 
 func (s *GasTestSuite) TestEstimatePriceWithPriority() {
 	for _, priority := range []string{"slow", "median", "fast"} {
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+		req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 		rec := httptest.NewRecorder()
 		c := s.echo.NewContext(req, rec)
 		c.SetPath("/gas/price/:priority")

--- a/cmd/api/handler/hyperlane_test.go
+++ b/cmd/api/handler/hyperlane_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/hex"
 	"encoding/json"
 	"maps"
@@ -218,7 +217,7 @@ func (s *HyperlaneTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *HyperlaneTestSuite) TearDownSuite() {
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteHyperlane_Run(t *testing.T) {
@@ -226,7 +225,7 @@ func TestSuiteHyperlane_Run(t *testing.T) {
 }
 
 func (s *HyperlaneTestSuite) TestGetMailbox() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/mailbox/:id")
@@ -261,7 +260,7 @@ func (s *HyperlaneTestSuite) TestGetMailbox() {
 }
 
 func (s *HyperlaneTestSuite) TestListMailboxes() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/mailbox")
@@ -296,7 +295,7 @@ func (s *HyperlaneTestSuite) TestListMailboxes() {
 }
 
 func (s *HyperlaneTestSuite) TestGetToken() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/token/:id")
@@ -332,7 +331,7 @@ func (s *HyperlaneTestSuite) TestGetToken() {
 }
 
 func (s *HyperlaneTestSuite) TestListToken() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/token")
@@ -368,7 +367,7 @@ func (s *HyperlaneTestSuite) TestListToken() {
 }
 
 func (s *HyperlaneTestSuite) TestGetTransfer() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/transfer/:id")
@@ -435,7 +434,7 @@ func (s *HyperlaneTestSuite) TestListTransferWithHash() {
 	q := make(url.Values)
 	q.Add("hash", testTxHash)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/transfer")
@@ -505,7 +504,7 @@ func (s *HyperlaneTestSuite) TestListTransferWithHash() {
 }
 
 func (s *HyperlaneTestSuite) TestListTransfer() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/transfer")
@@ -604,7 +603,7 @@ func (s *HyperlaneTestSuite) TestListTransferWithoutChainStore() {
 	s.chainStore = nil
 	s.handler = NewHyperlaneHandler(s.mailbox, s.token, s.transfer, s.txs, s.address, s.igp, nil)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/transfer")
@@ -652,7 +651,7 @@ func (s *HyperlaneTestSuite) TestListTransferWithoutChainStore() {
 }
 
 func (s *HyperlaneTestSuite) TestListDomains() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/domains")
@@ -694,7 +693,7 @@ func (s *HyperlaneTestSuite) TestListDomains() {
 }
 
 func (s *HyperlaneTestSuite) TestGetIgp() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/igp/:id")
@@ -750,7 +749,7 @@ func (s *HyperlaneTestSuite) TestGetIgp() {
 }
 
 func (s *HyperlaneTestSuite) TestListIgps() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/igp")

--- a/cmd/api/handler/ibc_test.go
+++ b/cmd/api/handler/ibc_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -147,7 +146,7 @@ func (s *IbcTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *IbcTestSuite) TearDownSuite() {
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteIbc_Run(t *testing.T) {
@@ -155,7 +154,7 @@ func TestSuiteIbc_Run(t *testing.T) {
 }
 
 func (s *IbcTestSuite) TestGet() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/ibc/client/:id")
@@ -191,7 +190,7 @@ func (s *IbcTestSuite) TestGet() {
 }
 
 func (s *IbcTestSuite) TestList() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/ibc/client")
@@ -231,7 +230,7 @@ func (s *IbcTestSuite) TestList() {
 }
 
 func (s *IbcTestSuite) TestGetConnection() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/ibc/connection/:id")
@@ -264,7 +263,7 @@ func (s *IbcTestSuite) TestGetConnection() {
 }
 
 func (s *IbcTestSuite) TestListConnection() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/ibc/connection")
@@ -300,7 +299,7 @@ func (s *IbcTestSuite) TestListConnection() {
 }
 
 func (s *IbcTestSuite) TestGetChannel() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/ibc/channel/:id")
@@ -336,7 +335,7 @@ func (s *IbcTestSuite) TestGetChannel() {
 }
 
 func (s *IbcTestSuite) TestListChannels() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/ibc/channel")
@@ -375,7 +374,7 @@ func (s *IbcTestSuite) TestListChannels() {
 }
 
 func (s *IbcTestSuite) TestListTransfers() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/ibc/transfer")
@@ -461,7 +460,7 @@ func (s *IbcTestSuite) TestListTransfersByChainId() {
 	q := make(url.Values)
 	q.Set("chain_id", "test")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/ibc/transfer")
@@ -558,7 +557,7 @@ func (s *IbcTestSuite) TestListTransfersByChainIdUnknownChain() {
 	q := make(url.Values)
 	q.Set("chain_id", "test")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/ibc/transfer")
@@ -578,7 +577,7 @@ func (s *IbcTestSuite) TestListTransfersByChainIdUnknownChain() {
 }
 
 func (s *IbcTestSuite) TestGetTransfer() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/ibc/transfer/:id")
@@ -660,7 +659,7 @@ func (s *IbcTestSuite) TestListTransferWithHash() {
 	q := make(url.Values)
 	q.Add("hash", testTxHash)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/ibc/transfer")
@@ -745,7 +744,7 @@ func (s *IbcTestSuite) TestListTransferWithHash() {
 }
 
 func (s *IbcTestSuite) TestAllRelayers() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/ibc/relayers")

--- a/cmd/api/handler/namespace_test.go
+++ b/cmd/api/handler/namespace_test.go
@@ -5,7 +5,6 @@ package handler
 
 import (
 	"bytes"
-	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
@@ -142,8 +141,7 @@ func (s *NamespaceTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *NamespaceTestSuite) TearDownSuite() {
-	s.ctrl.Finish()
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteNamespace_Run(t *testing.T) {
@@ -151,7 +149,7 @@ func TestSuiteNamespace_Run(t *testing.T) {
 }
 
 func (s *NamespaceTestSuite) TestGet() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/namespace/:id")
@@ -178,7 +176,7 @@ func (s *NamespaceTestSuite) TestGet() {
 }
 
 func (s *NamespaceTestSuite) TestGetInvalidNamespaceHeight() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/namespace/:id")
@@ -195,7 +193,7 @@ func (s *NamespaceTestSuite) TestGetInvalidNamespaceHeight() {
 }
 
 func (s *NamespaceTestSuite) TestList() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/namespace")
@@ -247,7 +245,7 @@ func (s *NamespaceTestSuite) TestListWithSort() {
 		q.Set("sort", request.Sort)
 		q.Set("sort_by", request.SortBy)
 
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+		req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 		rec := httptest.NewRecorder()
 		c := s.echo.NewContext(req, rec)
 		c.SetPath("/namespace")
@@ -275,7 +273,7 @@ func (s *NamespaceTestSuite) TestListWithSort() {
 }
 
 func (s *NamespaceTestSuite) TestGetWithVersion() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/namespace/:id/:version")
@@ -301,7 +299,7 @@ func (s *NamespaceTestSuite) TestGetWithVersion() {
 }
 
 func (s *NamespaceTestSuite) TestGetByHash() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/namespace_by_hash/:hash")
@@ -327,7 +325,7 @@ func (s *NamespaceTestSuite) TestGetByHash() {
 }
 
 func (s *NamespaceTestSuite) TestGetBlobs() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/namespace_by_hash/:hash/:height")
@@ -375,7 +373,7 @@ func (s *NamespaceTestSuite) TestGetBlobs() {
 }
 
 func (s *NamespaceTestSuite) TestGetMessages() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/namespace/:id/:version/messages")
@@ -435,7 +433,7 @@ func (s *NamespaceTestSuite) TestBlob() {
 	err := json.NewEncoder(stream).Encode(blobReq)
 	s.Require().NoError(err)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", stream)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodPost, "/", stream)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/blob")
@@ -474,7 +472,7 @@ func (s *NamespaceTestSuite) TestBlob() {
 }
 
 func (s *NamespaceTestSuite) TestGetLogs() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/namespace/:id/:version/logs")
@@ -531,7 +529,7 @@ func (s *NamespaceTestSuite) TestGetLogsBySigner() {
 	args := make(url.Values)
 	args.Set("signers", "celestia12zs7e3n8pjd8y8ex0cyv67ethv30mekgqu665r,celestia1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3y3clr6")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+args.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+args.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/namespace/:id/:version/logs")
@@ -600,7 +598,7 @@ func (s *NamespaceTestSuite) TestGetLogsWithCommitment() {
 	args := make(url.Values)
 	args.Set("commitment", cm)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+args.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+args.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/namespace/:id/:version/logs")
@@ -653,7 +651,7 @@ func (s *NamespaceTestSuite) TestGetLogsWithCommitment() {
 }
 
 func (s *NamespaceTestSuite) TestRollups() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/namespace/:id/:version/rollups")
@@ -695,7 +693,7 @@ func (s *NamespaceTestSuite) TestBlobMetadata() {
 	err := json.NewEncoder(stream).Encode(blobReq)
 	s.Require().NoError(err)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", stream)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodPost, "/", stream)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/blob/metadata")
@@ -742,7 +740,7 @@ func (s *NamespaceTestSuite) TestBlobMetadata() {
 }
 
 func (s *NamespaceTestSuite) TestBlobs() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/blobs")
@@ -800,7 +798,7 @@ func (s *NamespaceTestSuite) TestBlobProofs() {
 	err := json.NewEncoder(stream).Encode(proofReq)
 	s.Require().NoError(err)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", stream)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodPost, "/", stream)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/blob/proofs")

--- a/cmd/api/handler/proposals_test.go
+++ b/cmd/api/handler/proposals_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -68,7 +67,6 @@ func (s *ProposalTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *ProposalTestSuite) TearDownSuite() {
-	s.ctrl.Finish()
 	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
@@ -77,7 +75,7 @@ func TestSuiteProposal_Run(t *testing.T) {
 }
 
 func (s *ProposalTestSuite) TestList() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/proposal")
@@ -106,7 +104,7 @@ func (s *ProposalTestSuite) TestList() {
 }
 
 func (s *ProposalTestSuite) TestGet() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/proposal/:id")
@@ -140,7 +138,7 @@ func (s *ProposalTestSuite) TestVotes() {
 	q.Set("limit", "10")
 	q.Set("offset", "0")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/proposal/:id/votes")
@@ -216,7 +214,7 @@ func (s *ProposalTestSuite) TestVotesByProposalIdWithVoter() {
 	q.Set("offset", "0")
 	q.Set("address", testAddress)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/proposal/:id/votes")
@@ -296,7 +294,7 @@ func (s *ProposalTestSuite) TestVotesByProposalIdWithValidator() {
 	q.Set("offset", "0")
 	q.Set("validator", "celestiavaloper1qycj0ymu9fqvwgyw4xz93p3n4a83jjk7sm2wzh")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/proposal/:id/votes")

--- a/cmd/api/handler/rollup_test.go
+++ b/cmd/api/handler/rollup_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -89,8 +88,7 @@ func (s *RollupTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *RollupTestSuite) TearDownSuite() {
-	s.ctrl.Finish()
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteRollup_Run(t *testing.T) {
@@ -113,7 +111,7 @@ func (s *RollupTestSuite) TestLeaderboard() {
 		q.Add("provider", "provider 1")
 		q.Add("is_active", "true")
 
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+		req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 		rec := httptest.NewRecorder()
 		c := s.echo.NewContext(req, rec)
 		c.SetPath("/rollup")
@@ -176,7 +174,7 @@ func (s *RollupTestSuite) TestLeaderboardDay() {
 		q.Add("stack", "stack 1,stack 2")
 		q.Add("provider", "provider 1")
 
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+		req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 		rec := httptest.NewRecorder()
 		c := s.echo.NewContext(req, rec)
 		c.SetPath("/rollup/day")
@@ -227,7 +225,7 @@ func (s *RollupTestSuite) TestLeaderboardDay() {
 }
 
 func (s *RollupTestSuite) TestGet() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/rollup/:id")
@@ -260,7 +258,7 @@ func (s *RollupTestSuite) TestGet() {
 }
 
 func (s *RollupTestSuite) TestGetNamespaces() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/rollup/:id/namespaces")
@@ -293,7 +291,7 @@ func (s *RollupTestSuite) TestGetNamespaces() {
 }
 
 func (s *RollupTestSuite) TestGetProviders() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/rollup/:id/providers")
@@ -346,7 +344,7 @@ func (s *RollupTestSuite) TestGetProviders() {
 }
 
 func (s *RollupTestSuite) TestGetBlobs() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/rollup/:id/blobs")
@@ -409,7 +407,7 @@ func (s *RollupTestSuite) TestGetBlobs() {
 func (s *RollupTestSuite) TestStats() {
 	for _, name := range []string{"blobs_count", "size", "size_per_blob", "fee"} {
 		for _, tf := range []storage.Timeframe{storage.TimeframeHour, storage.TimeframeDay, storage.TimeframeMonth} {
-			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 			rec := httptest.NewRecorder()
 			c := s.echo.NewContext(req, rec)
 			c.SetPath("/rollup/:id/stats/:name/:timeframe")
@@ -439,7 +437,7 @@ func (s *RollupTestSuite) TestStats() {
 func (s *RollupTestSuite) TestDistribution() {
 	for _, name := range []string{"blobs_count", "size", "size_per_blob", "fee_per_blob"} {
 		for _, tf := range []storage.Timeframe{storage.TimeframeHour, storage.TimeframeDay} {
-			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 			rec := httptest.NewRecorder()
 			c := s.echo.NewContext(req, rec)
 			c.SetPath("/rollup/:id/distribution/:name/:timeframe")
@@ -467,7 +465,7 @@ func (s *RollupTestSuite) TestDistribution() {
 }
 
 func (s *RollupTestSuite) TestBySlug() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/rollup/slug/:slug")
@@ -499,7 +497,7 @@ func (s *RollupTestSuite) TestByExportBlobs() {
 	q.Set("from", "1")
 	q.Set("to", "2")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/rollup/:id/export")
@@ -538,7 +536,7 @@ func (s *RollupTestSuite) TestAllSeries() {
 		storage.TimeframeDay,
 		storage.TimeframeMonth,
 	} {
-		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+		req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 		rec := httptest.NewRecorder()
 		c := s.echo.NewContext(req, rec)
 		c.SetPath("/rollup/stats/series/:timeframe")
@@ -595,7 +593,7 @@ func (s *RollupTestSuite) TestRollupStatsGrouping() {
 			q.Add("func", funcName)
 			q.Add("column", groupName)
 
-			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+			req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 			rec := httptest.NewRecorder()
 			c := s.echo.NewContext(req, rec)
 			c.SetPath("/rollup/group")

--- a/cmd/api/handler/search_test.go
+++ b/cmd/api/handler/search_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
@@ -61,8 +60,7 @@ func (s *SearchTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *SearchTestSuite) TearDownSuite() {
-	s.ctrl.Finish()
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteSearch_Run(t *testing.T) {
@@ -73,7 +71,7 @@ func (s *SearchTestSuite) TestSearchAddress() {
 	q := make(url.Values)
 	q.Set("query", testAddress)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/search")
@@ -107,7 +105,7 @@ func (s *SearchTestSuite) TestSearchBlock() {
 	q := make(url.Values)
 	q.Set("query", searchText)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/search")
@@ -145,7 +143,7 @@ func (s *SearchTestSuite) TestSearchBlockByHeight() {
 	q := make(url.Values)
 	q.Set("query", "100")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/search")
@@ -183,7 +181,7 @@ func (s *SearchTestSuite) TestSearchBlockWith0x() {
 	q := make(url.Values)
 	q.Set("query", searchText)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/search")
@@ -221,7 +219,7 @@ func (s *SearchTestSuite) TestSearchBlockWithInvalidHash() {
 	q := make(url.Values)
 	q.Set("query", "EDBOFE1DAA9BB1FDA0879F1EB4F285399B6F74CB1B0C420600642682043EE41E")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/search")
@@ -239,7 +237,7 @@ func (s *SearchTestSuite) TestSearchTx() {
 	q := make(url.Values)
 	q.Set("query", testTxHash)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/search")
@@ -277,7 +275,7 @@ func (s *SearchTestSuite) TestSearchNamespaceById() {
 	q := make(url.Values)
 	q.Set("query", "00"+testNamespaceId)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/search")
@@ -303,7 +301,7 @@ func (s *SearchTestSuite) TestSearchNamespaceByBase64() {
 	q := make(url.Values)
 	q.Set("query", testNamespaceBase64)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/search")
@@ -330,7 +328,7 @@ func (s *SearchTestSuite) TestSearchValidator() {
 	q := make(url.Values)
 	q.Set("query", "name")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/search")
@@ -372,7 +370,7 @@ func (s *SearchTestSuite) TestSearchRollup() {
 	q := make(url.Values)
 	q.Set("query", "name")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/search")
@@ -413,7 +411,7 @@ func (s *SearchTestSuite) TestSearchTextNamespace() {
 	q := make(url.Values)
 	q.Set("query", "5f45")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/search")
@@ -455,7 +453,7 @@ func (s *SearchTestSuite) TestSearchCelestial() {
 	q := make(url.Values)
 	q.Set("query", "name")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/search")
@@ -507,7 +505,7 @@ func (s *SearchTestSuite) TestSearchNoResult() {
 	q := make(url.Values)
 	q.Set("query", "unknown")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/search")
@@ -525,7 +523,7 @@ func (s *SearchTestSuite) TestSearchUnknownAddress() {
 	q := make(url.Values)
 	q.Set("query", testAddress)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/search")

--- a/cmd/api/handler/signal_test.go
+++ b/cmd/api/handler/signal_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
@@ -94,7 +93,6 @@ func (s *SignalTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *SignalTestSuite) TearDownSuite() {
-	s.ctrl.Finish()
 	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
@@ -108,7 +106,7 @@ func (s *SignalTestSuite) TestList() {
 	q.Set("offset", "0")
 	q.Set("validator_id", "1")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/signal")
@@ -151,7 +149,7 @@ func (s *SignalTestSuite) TestUpgrades() {
 	q.Set("offset", "0")
 	q.Set("height", "101")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/signal/upgrade")
@@ -189,7 +187,7 @@ func (s *SignalTestSuite) TestUpgrades() {
 }
 
 func (s *SignalTestSuite) TestUpgrade() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/signal/upgrade/:version")

--- a/cmd/api/handler/state_test.go
+++ b/cmd/api/handler/state_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"database/sql"
 	"encoding/json"
 	"net/http"
@@ -44,8 +43,7 @@ func (s *StateTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *StateTestSuite) TearDownSuite() {
-	s.ctrl.Finish()
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteState_Run(t *testing.T) {
@@ -53,7 +51,7 @@ func TestSuiteState_Run(t *testing.T) {
 }
 
 func (s *StateTestSuite) TestHead() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/head")
@@ -110,7 +108,7 @@ func (s *StateTestSuite) TestHead() {
 }
 
 func (s *StateTestSuite) TestNoHead() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/head")

--- a/cmd/api/handler/stats_test.go
+++ b/cmd/api/handler/stats_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -56,8 +55,7 @@ func (s *StatsTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *StatsTestSuite) TearDownSuite() {
-	s.ctrl.Finish()
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteStats_Run(t *testing.T) {
@@ -65,7 +63,7 @@ func TestSuiteStats_Run(t *testing.T) {
 }
 
 func (s *StatsTestSuite) TestCountBlocks() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/v1/stats/summary/:table/:function")
@@ -91,7 +89,7 @@ func (s *StatsTestSuite) TestSumFeeBlocks() {
 	q := make(url.Values)
 	q.Set("column", "fee")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/v1/stats/summary/:table/:function")
@@ -118,7 +116,7 @@ func (s *StatsTestSuite) TestSumFeeBlocks() {
 }
 
 func (s *StatsTestSuite) TestCountBlocksBadRequest() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/v1/stats/summary/:table/:function")
@@ -130,7 +128,7 @@ func (s *StatsTestSuite) TestCountBlocksBadRequest() {
 }
 
 func (s *StatsTestSuite) TestTPS() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/v1/stats/tps")
@@ -158,7 +156,7 @@ func (s *StatsTestSuite) TestTPS() {
 }
 
 func (s *StatsTestSuite) TestChanges24hBlockStats() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/v1/stats/changes_24h")
@@ -189,7 +187,7 @@ func (s *StatsTestSuite) TestNamespaceUsage() {
 	q := make(url.Values)
 	q.Set("top", "1")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/v1/stats/namespace/usage")
@@ -252,7 +250,7 @@ func (s *StatsTestSuite) TestBlockStatsHistogram() {
 			storage.TimeframeMonth,
 			storage.TimeframeYear,
 		} {
-			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 			rec := httptest.NewRecorder()
 			c := s.echo.NewContext(req, rec)
 			c.SetPath("/v1/stats/series/:name/:timeframe")
@@ -303,7 +301,7 @@ func (s *StatsTestSuite) TestBlockCumulativeStatsHistogram() {
 			storage.TimeframeMonth,
 			storage.TimeframeYear,
 		} {
-			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 			rec := httptest.NewRecorder()
 			c := s.echo.NewContext(req, rec)
 			c.SetPath("/v1/stats/series/:name/:timeframe/cumulative")
@@ -346,7 +344,7 @@ func (s *StatsTestSuite) TestNamespaceStatsHistogram() {
 			storage.TimeframeMonth,
 			storage.TimeframeYear,
 		} {
-			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 			rec := httptest.NewRecorder()
 			c := s.echo.NewContext(req, rec)
 			c.SetPath("/v1/stats/namespace/series/:id/:name/:timeframe")
@@ -383,7 +381,7 @@ func (s *StatsTestSuite) TestNamespaceStatsHistogram() {
 }
 
 func (s *StatsTestSuite) TestSquareSize() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/v1/stats/square_size")
@@ -429,7 +427,7 @@ func (s *StatsTestSuite) TestCumulativeSeries() {
 			storage.TimeframeMonth,
 			storage.TimeframeYear,
 		} {
-			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 			rec := httptest.NewRecorder()
 			c := s.echo.NewContext(req, rec)
 			c.SetPath("/v1/stats/series/:name/:timeframe")
@@ -460,7 +458,7 @@ func (s *StatsTestSuite) TestCumulativeSeries() {
 }
 
 func (s *StatsTestSuite) TestRollupStats24h() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/v1/stats/rollup_stats_24h")
@@ -496,7 +494,7 @@ func (s *StatsTestSuite) TestRollupStats24h() {
 }
 
 func (s *StatsTestSuite) TestMessgaesCount24h() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/v1/stats/messages_count_24h")
@@ -523,7 +521,7 @@ func (s *StatsTestSuite) TestMessgaesCount24h() {
 }
 
 func (s *StatsTestSuite) TestSizeGroups() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/v1/stats/size_groups")
@@ -564,7 +562,7 @@ func (s *StatsTestSuite) TestIbcSeries() {
 			storage.TimeframeDay,
 			storage.TimeframeMonth,
 		} {
-			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 			rec := httptest.NewRecorder()
 			c := s.echo.NewContext(req, rec)
 			c.SetPath("/v1/stats/ibc/series/:id/:name/:timeframe")
@@ -595,7 +593,7 @@ func (s *StatsTestSuite) TestIbcSeries() {
 }
 
 func (s *StatsTestSuite) TestIbcChainStats() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/v1/stats/ibc/chains")
@@ -626,7 +624,7 @@ func (s *StatsTestSuite) TestIbcChainStats() {
 }
 
 func (s *StatsTestSuite) TestIbcSummaryStats() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/v1/stats/ibc/summary")
@@ -683,7 +681,7 @@ func (s *StatsTestSuite) TestIbcSummaryStats() {
 }
 
 func (s *StatsTestSuite) TestHlDomainStats() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/v1/stats/hyperlane/chains")
@@ -742,7 +740,7 @@ func (s *StatsTestSuite) TestHlSeries() {
 			storage.TimeframeDay,
 			storage.TimeframeMonth,
 		} {
-			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 			rec := httptest.NewRecorder()
 			c := s.echo.NewContext(req, rec)
 			c.SetPath("/v1/stats/hyperlane/series/:id/:name/:timeframe")
@@ -776,7 +774,7 @@ func (s *StatsTestSuite) TestHlDomainStatsWithoutChainStore() {
 	s.chainStore = nil
 	s.handler = NewStatsHandler(s.stats, s.ns, s.ibc, s.channels, s.hyperlane, nil, s.state)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/v1/stats/hyperlane/chains")
@@ -817,7 +815,7 @@ func (s *StatsTestSuite) TestHlTotalSeries() {
 			storage.TimeframeDay,
 			storage.TimeframeMonth,
 		} {
-			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 			rec := httptest.NewRecorder()
 			c := s.echo.NewContext(req, rec)
 			c.SetPath("/v1/stats/hyperlane/chains/:name/:timeframe")
@@ -864,7 +862,7 @@ func (s *StatsTestSuite) TestStakingSeries() {
 			storage.TimeframeDay,
 			storage.TimeframeMonth,
 		} {
-			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+			req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 			rec := httptest.NewRecorder()
 			c := s.echo.NewContext(req, rec)
 			c.SetPath("/v1/stats/staking/series/:id/:name/:timeframe")
@@ -895,7 +893,7 @@ func (s *StatsTestSuite) TestStakingSeries() {
 }
 
 func (s *StatsTestSuite) TestSStakingDistribution() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/v1/stats/staking/distribution")

--- a/cmd/api/handler/tx_test.go
+++ b/cmd/api/handler/tx_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
@@ -91,8 +90,7 @@ func (s *TxTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *TxTestSuite) TearDownSuite() {
-	s.ctrl.Finish()
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteTx_Run(t *testing.T) {
@@ -100,7 +98,7 @@ func TestSuiteTx_Run(t *testing.T) {
 }
 
 func (s *TxTestSuite) TestGet() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx/:hash")
@@ -136,7 +134,7 @@ func (s *TxTestSuite) TestGet() {
 }
 
 func (s *TxTestSuite) TestGetInvalidTx() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx/:hash")
@@ -160,7 +158,7 @@ func (s *TxTestSuite) TestList() {
 	q.Set("status", "success")
 	q.Set("msg_type", "MsgUnjail,MsgSend")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx")
@@ -203,7 +201,7 @@ func (s *TxTestSuite) TestListWithHeight() {
 	q.Set("limit", "2")
 	q.Set("height", "100")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx")
@@ -233,7 +231,7 @@ func (s *TxTestSuite) TestListWithHeightAndFrom() {
 	q.Set("height", "100")
 	q.Set("from", "1690851660") // unix for testTime
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx")
@@ -262,7 +260,7 @@ func (s *TxTestSuite) TestListWithHeightNotFound() {
 	q := make(url.Values)
 	q.Set("height", "999999999")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx")
@@ -292,7 +290,7 @@ func (s *TxTestSuite) TestListValidationStatusError() {
 	q.Set("status", "invalid")
 	q.Set("msg_type", "MsgUnjail,MsgSend")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx")
@@ -314,7 +312,7 @@ func (s *TxTestSuite) TestListValidationMsgTypeError() {
 	q.Set("status", "success")
 	q.Set("msg_type", "invalid,MsgSend")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx")
@@ -338,7 +336,7 @@ func (s *TxTestSuite) TestListTime() {
 	q.Set("from", "1692880000")
 	q.Set("to", "1692890000")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx")
@@ -386,7 +384,7 @@ func (s *TxTestSuite) TestListHeight() {
 	q.Set("height", "1000")
 	q.Set("messages", "true")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx")
@@ -459,7 +457,7 @@ func (s *TxTestSuite) TestListExcludedMessages() {
 		Return(blockTime, nil).
 		Times(1)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx")
@@ -515,7 +513,7 @@ func (s *TxTestSuite) TestGetEvents() {
 	q.Set("limit", "2")
 	q.Set("offset", "0")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx/:hash/events")
@@ -562,7 +560,7 @@ func (s *TxTestSuite) TestGetMessage() {
 	q.Set("limit", "2")
 	q.Set("offset", "0")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx/:hash/events")
@@ -605,7 +603,7 @@ func (s *TxTestSuite) TestGetMessage() {
 }
 
 func (s *TxTestSuite) TestCount() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx/count")
@@ -624,7 +622,7 @@ func (s *TxTestSuite) TestCount() {
 }
 
 func (s *TxTestSuite) TestGenesis() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx/genesis")
@@ -658,7 +656,7 @@ func (s *TxTestSuite) TestGenesis() {
 }
 
 func (s *TxTestSuite) TestBlobs() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx/:hash/blobs")
@@ -715,7 +713,7 @@ func (s *TxTestSuite) TestListWithCursorAsc() {
 	q.Set("cursor", "5")
 	q.Set("sort", "asc")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx")
@@ -746,7 +744,7 @@ func (s *TxTestSuite) TestListWithCursorDesc() {
 	q.Set("cursor", "3")
 	q.Set("sort", "desc")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx")
@@ -778,7 +776,7 @@ func (s *TxTestSuite) TestListWithCursorAndMsgType() {
 	q.Set("msg_type", "MsgSend")
 	q.Set("sort", "asc")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx")
@@ -805,7 +803,7 @@ func (s *TxTestSuite) TestListWithCursorAndMsgType() {
 }
 
 func (s *TxTestSuite) TestBlobsCount() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/tx/:hash/blobs/count")

--- a/cmd/api/handler/validator_test.go
+++ b/cmd/api/handler/validator_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -56,8 +55,7 @@ func (s *ValidatorTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *ValidatorTestSuite) TearDownSuite() {
-	s.ctrl.Finish()
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteValidator_Run(t *testing.T) {
@@ -65,7 +63,7 @@ func TestSuiteValidator_Run(t *testing.T) {
 }
 
 func (s *ValidatorTestSuite) TestGet() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/validators/:id")
@@ -88,7 +86,7 @@ func (s *ValidatorTestSuite) TestGet() {
 }
 
 func (s *ValidatorTestSuite) TestList() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/validator")
@@ -117,7 +115,7 @@ func (s *ValidatorTestSuite) TestListWithVersion() {
 	q := make(url.Values)
 	q.Add("version", "4")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/validator")
@@ -145,7 +143,7 @@ func (s *ValidatorTestSuite) TestListWithVersion() {
 }
 
 func (s *ValidatorTestSuite) TestByProposer() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/validator/:id")
@@ -180,7 +178,7 @@ func (s *ValidatorTestSuite) TestUptime() {
 	q := make(url.Values)
 	q.Add("limit", "4")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/validators/:id/uptime")
@@ -215,7 +213,7 @@ func (s *ValidatorTestSuite) TestUptimeUnusual() {
 	q := make(url.Values)
 	q.Add("limit", "10")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/validators/:id/uptime")
@@ -252,7 +250,7 @@ func (s *ValidatorTestSuite) TestDelegators() {
 	q.Set("offset", "0")
 	q.Set("show_zero", "true")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/validators/:id/delegators")
@@ -292,7 +290,7 @@ func (s *ValidatorTestSuite) TestJails() {
 	q.Set("limit", "10")
 	q.Set("offset", "0")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/validators/:id/jails")
@@ -326,7 +324,7 @@ func (s *ValidatorTestSuite) TestJails() {
 }
 
 func (s *ValidatorTestSuite) TestCount() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/validators/count")
@@ -369,7 +367,7 @@ func (s *ValidatorTestSuite) TestVotes() {
 	q.Set("limit", "10")
 	q.Set("offset", "0")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/validators/:id/votes")
@@ -413,7 +411,7 @@ func (s *ValidatorTestSuite) TestMessages() {
 	q.Set("limit", "10")
 	q.Set("offset", "0")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/validators/:id/messages")
@@ -459,7 +457,7 @@ func (s *ValidatorTestSuite) TestMessages() {
 }
 
 func (s *ValidatorTestSuite) TestMetrics() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/validators/:id/metrics")
@@ -512,7 +510,7 @@ func (s *ValidatorTestSuite) TestMetrics() {
 }
 
 func (s *ValidatorTestSuite) TestTopNMetrics() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/validators/metrics")

--- a/cmd/api/handler/vesting_test.go
+++ b/cmd/api/handler/vesting_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -40,7 +39,7 @@ func (s *VestingTestSuite) SetupSuite() {
 
 // TearDownSuite -
 func (s *VestingTestSuite) TearDownSuite() {
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteVesting_Run(t *testing.T) {
@@ -51,7 +50,7 @@ func (s *VestingTestSuite) TestPeriods() {
 	q := make(url.Values)
 	q.Set("limit", "5")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/vesting/:id/periods")

--- a/cmd/api/handler/zkism_test.go
+++ b/cmd/api/handler/zkism_test.go
@@ -4,7 +4,6 @@
 package handler
 
 import (
-	"context"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
@@ -102,7 +101,7 @@ func (s *ZkISMTestSuite) SetupSuite() {
 }
 
 func (s *ZkISMTestSuite) TearDownSuite() {
-	s.Require().NoError(s.echo.Shutdown(context.Background()))
+	s.Require().NoError(s.echo.Shutdown(s.T().Context()))
 }
 
 func TestSuiteZkISM_Run(t *testing.T) {
@@ -114,7 +113,7 @@ func TestSuiteZkISM_Run(t *testing.T) {
 // ──────────────────────────────────────────────────────────
 
 func (s *ZkISMTestSuite) TestList() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism")
@@ -149,7 +148,7 @@ func (s *ZkISMTestSuite) TestList() {
 }
 
 func (s *ZkISMTestSuite) TestListEmpty() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism")
@@ -176,7 +175,7 @@ func (s *ZkISMTestSuite) TestListWithLimitOffset() {
 	q.Set("limit", "5")
 	q.Set("offset", "10")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism")
@@ -202,7 +201,7 @@ func (s *ZkISMTestSuite) TestListWithAddress() {
 	q := make(url.Values)
 	q.Set("address", testAddress)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism")
@@ -235,7 +234,7 @@ func (s *ZkISMTestSuite) TestListWithTxHash() {
 	q := make(url.Values)
 	q.Set("tx_hash", strings.ToLower(testTxHash))
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism")
@@ -268,7 +267,7 @@ func (s *ZkISMTestSuite) TestListValidationError() {
 	q := make(url.Values)
 	q.Set("limit", "200")
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism")
@@ -282,7 +281,7 @@ func (s *ZkISMTestSuite) TestListValidationError() {
 // ──────────────────────────────────────────────────────────
 
 func (s *ZkISMTestSuite) TestGet() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism/:id")
@@ -313,7 +312,7 @@ func (s *ZkISMTestSuite) TestGet() {
 }
 
 func (s *ZkISMTestSuite) TestGetValidationError() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism/:id")
@@ -329,7 +328,7 @@ func (s *ZkISMTestSuite) TestGetValidationError() {
 // ──────────────────────────────────────────────────────────
 
 func (s *ZkISMTestSuite) TestGetUpdates() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism/:id/updates")
@@ -362,7 +361,7 @@ func (s *ZkISMTestSuite) TestGetUpdates() {
 }
 
 func (s *ZkISMTestSuite) TestGetUpdatesEmpty() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism/:id/updates")
@@ -390,7 +389,7 @@ func (s *ZkISMTestSuite) TestGetUpdatesWithAddress() {
 	q := make(url.Values)
 	q.Set("address", testAddress)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism/:id/updates")
@@ -422,7 +421,7 @@ func (s *ZkISMTestSuite) TestGetUpdatesWithAddress() {
 }
 
 func (s *ZkISMTestSuite) TestGetUpdatesValidationError() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism/:id/updates")
@@ -438,7 +437,7 @@ func (s *ZkISMTestSuite) TestGetUpdatesValidationError() {
 // ──────────────────────────────────────────────────────────
 
 func (s *ZkISMTestSuite) TestGetMessages() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism/:id/messages")
@@ -473,7 +472,7 @@ func (s *ZkISMTestSuite) TestGetMessages() {
 }
 
 func (s *ZkISMTestSuite) TestGetMessagesEmpty() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism/:id/messages")
@@ -501,7 +500,7 @@ func (s *ZkISMTestSuite) TestGetMessagesWithAddress() {
 	q := make(url.Values)
 	q.Set("address", testAddress)
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism/:id/messages")
@@ -536,7 +535,7 @@ func (s *ZkISMTestSuite) TestGetMessagesWithTxHash() {
 	q := make(url.Values)
 	q.Set("tx_hash", strings.ToLower(testTxHash))
 
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/?"+q.Encode(), nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/?"+q.Encode(), nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism/:id/messages")
@@ -568,7 +567,7 @@ func (s *ZkISMTestSuite) TestGetMessagesWithTxHash() {
 }
 
 func (s *ZkISMTestSuite) TestGetMessagesValidationError() {
-	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/", nil)
+	req := httptest.NewRequestWithContext(s.T().Context(), http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
 	c := s.echo.NewContext(req, rec)
 	c.SetPath("/hyperlane/zkism/:id/messages")

--- a/internal/storage/postgres/address_test.go
+++ b/internal/storage/postgres/address_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestAddressByHash() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	hash := []byte{0xde, 0xce, 0x42, 0x5b, 0x75, 0xd6, 0x71, 0x15, 0xbd, 0xa8, 0x77, 0xe1, 0xe7, 0xa1, 0xf2, 0x62, 0xf6, 0xfa, 0x51, 0xd6}
@@ -29,7 +29,7 @@ func (s *StorageTestSuite) TestAddressByHash() {
 }
 
 func (s *StorageTestSuite) TestIcaAddressByHash() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	hash := []byte{48, 160, 217, 234, 151, 39, 229, 141, 230, 127, 49, 37, 182, 237, 136, 189, 218, 247, 87, 139, 87, 173, 20, 154, 154, 144, 84, 29, 23, 55, 212, 7}
@@ -45,7 +45,7 @@ func (s *StorageTestSuite) TestIcaAddressByHash() {
 }
 
 func (s *StorageTestSuite) TestAddressByString() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	hash := []byte{48, 160, 217, 234, 151, 39, 229, 141, 230, 127, 49, 37, 182, 237, 136, 189, 218, 247, 87, 139, 87, 173, 20, 154, 154, 144, 84, 29, 23, 55, 212, 7}
@@ -58,7 +58,7 @@ func (s *StorageTestSuite) TestAddressByString() {
 }
 
 func (s *StorageTestSuite) TestAddressByHashWithoutCelestials() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	hash := []byte{0xC0, 0xD4, 0xB7, 0x92, 0x82, 0xE1, 0x60, 0x4E, 0xEB, 0xCB, 0x2C, 0x02, 0xF6, 0x2C, 0xB8, 0x37, 0x37, 0x57, 0x9C, 0x9C}
@@ -71,7 +71,7 @@ func (s *StorageTestSuite) TestAddressByHashWithoutCelestials() {
 }
 
 func (s *StorageTestSuite) TestAddressList() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	addresses, err := s.storage.Address.ListWithBalance(ctx, storage.AddressListFilter{
@@ -108,7 +108,7 @@ func (s *StorageTestSuite) TestAddressList() {
 }
 
 func (s *StorageTestSuite) TestAddressListWithSortAscHeight() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, field := range []string{"first_height", "last_height"} {
@@ -138,7 +138,7 @@ func (s *StorageTestSuite) TestAddressListWithSortAscHeight() {
 }
 
 func (s *StorageTestSuite) TestAddressListWithSortDescHeight() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, field := range []string{"first_height", "last_height"} {
@@ -161,7 +161,7 @@ func (s *StorageTestSuite) TestAddressListWithSortDescHeight() {
 }
 
 func (s *StorageTestSuite) TestAddressListWithSortDesc() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, field := range []string{"delegated", "spendable", "unbonding"} {
@@ -209,7 +209,7 @@ func (s *StorageTestSuite) TestAddressListWithSortDesc() {
 }
 
 func (s *StorageTestSuite) TestAddressListWithSortAsc() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, field := range []string{"delegated", "spendable", "unbonding"} {
@@ -245,7 +245,7 @@ func (s *StorageTestSuite) TestAddressListWithSortAsc() {
 }
 
 func (s *StorageTestSuite) TestAddressMessages() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	messages, err := s.storage.Message.ByAddress(ctx, 1, storage.AddressMsgsFilter{
@@ -267,7 +267,7 @@ func (s *StorageTestSuite) TestAddressMessages() {
 }
 
 func (s *StorageTestSuite) TestAddressMessagesWithType() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	messages, err := s.storage.Message.ByAddress(ctx, 1, storage.AddressMsgsFilter{
@@ -289,7 +289,7 @@ func (s *StorageTestSuite) TestAddressMessagesWithType() {
 }
 
 func (s *StorageTestSuite) TestAddressStats() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, name := range []string{"tx_count", "fee", "gas_wanted", "gas_used"} {
@@ -305,7 +305,7 @@ func (s *StorageTestSuite) TestAddressStats() {
 }
 
 func (s *StorageTestSuite) TestAddressStatsError() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.Address.Series(ctx, 1, storage.TimeframeDay, "invalid", storage.NewSeriesRequest(0, 0))
@@ -316,7 +316,7 @@ func (s *StorageTestSuite) TestAddressStatsError() {
 }
 
 func (s *StorageTestSuite) TestAddressIdByHash() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	hash := []byte{0xde, 0xce, 0x42, 0x5b, 0x75, 0xd6, 0x71, 0x15, 0xbd, 0xa8, 0x77, 0xe1, 0xe7, 0xa1, 0xf2, 0x62, 0xf6, 0xfa, 0x51, 0xd6}
@@ -327,7 +327,7 @@ func (s *StorageTestSuite) TestAddressIdByHash() {
 }
 
 func (s *StorageTestSuite) TestAddressIdByAddress() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	id, err := s.storage.Address.IdByAddress(ctx, "celestia1jc92qdnty48pafummfr8ava2tjtuhfdw774w60", 2, 3, 4)
@@ -336,7 +336,7 @@ func (s *StorageTestSuite) TestAddressIdByAddress() {
 }
 
 func (s *StorageTestSuite) TestBalances() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	balances, err := s.storage.Address.Balances(ctx, 5, 10, 0)

--- a/internal/storage/postgres/apikey_test.go
+++ b/internal/storage/postgres/apikey_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestApiKeyValid() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	key, err := s.storage.ApiKeys.Get(ctx, "test_key")
@@ -19,7 +19,7 @@ func (s *StorageTestSuite) TestApiKeyValid() {
 }
 
 func (s *StorageTestSuite) TestApiKeyInvalid() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.ApiKeys.Get(ctx, "invalid")

--- a/internal/storage/postgres/blob_log_test.go
+++ b/internal/storage/postgres/blob_log_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestBlobLogsByNamespace() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	logs, err := s.storage.BlobLogs.ByNamespace(ctx, 2, storage.BlobLogFilters{
@@ -50,7 +50,7 @@ func (s *StorageTestSuite) TestBlobLogsByNamespace() {
 }
 
 func (s *StorageTestSuite) TestBlobLogsByNamespaceWithoutJoins() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	logs, err := s.storage.BlobLogs.ByNamespace(ctx, 2, storage.BlobLogFilters{
@@ -79,7 +79,7 @@ func (s *StorageTestSuite) TestBlobLogsByNamespaceWithoutJoins() {
 }
 
 func (s *StorageTestSuite) TestBlobLogsByNamespaceAndCommitment() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	logs, err := s.storage.BlobLogs.ByNamespace(ctx, 2, storage.BlobLogFilters{
@@ -110,7 +110,7 @@ func (s *StorageTestSuite) TestBlobLogsByNamespaceAndCommitment() {
 }
 
 func (s *StorageTestSuite) TestBlobLogsByNamespaceAndTime() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	logs, err := s.storage.BlobLogs.ByNamespace(ctx, 2, storage.BlobLogFilters{
@@ -141,7 +141,7 @@ func (s *StorageTestSuite) TestBlobLogsByNamespaceAndTime() {
 }
 
 func (s *StorageTestSuite) TestBlobLogsByNamespaceAndHeight() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	logs, err := s.storage.BlobLogs.ByNamespace(ctx, 2, storage.BlobLogFilters{
@@ -172,7 +172,7 @@ func (s *StorageTestSuite) TestBlobLogsByNamespaceAndHeight() {
 }
 
 func (s *StorageTestSuite) TestBlobLogsByNamespaceAndToTime() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	logs, err := s.storage.BlobLogs.ByNamespace(ctx, 2, storage.BlobLogFilters{
@@ -203,7 +203,7 @@ func (s *StorageTestSuite) TestBlobLogsByNamespaceAndToTime() {
 }
 
 func (s *StorageTestSuite) TestBlobLogsSigner() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	logs, err := s.storage.BlobLogs.BySigner(ctx, 1, storage.BlobLogFilters{
@@ -230,7 +230,7 @@ func (s *StorageTestSuite) TestBlobLogsSigner() {
 }
 
 func (s *StorageTestSuite) TestBlobLogsSignerWithoutJoins() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	logs, err := s.storage.BlobLogs.BySigner(ctx, 1, storage.BlobLogFilters{
@@ -257,7 +257,7 @@ func (s *StorageTestSuite) TestBlobLogsSignerWithoutJoins() {
 }
 
 func (s *StorageTestSuite) TestBlobLogsTx() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	logs, err := s.storage.BlobLogs.ByTxId(ctx, 4, storage.BlobLogFilters{
@@ -287,7 +287,7 @@ func (s *StorageTestSuite) TestBlobLogsTx() {
 }
 
 func (s *StorageTestSuite) TestCountBlobLogsTx() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	count, err := s.storage.BlobLogs.CountByTxId(ctx, 4)
@@ -296,7 +296,7 @@ func (s *StorageTestSuite) TestCountBlobLogsTx() {
 }
 
 func (s *StorageTestSuite) TestBlobLogsByHeight() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	logs, err := s.storage.BlobLogs.ByHeight(ctx, 1000, storage.BlobLogFilters{
@@ -326,7 +326,7 @@ func (s *StorageTestSuite) TestBlobLogsByHeight() {
 }
 
 func (s *StorageTestSuite) TestBlobLogsByProviders() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, sortBy := range []string{"", "time", "size"} {
@@ -351,7 +351,7 @@ func (s *StorageTestSuite) TestBlobLogsByProviders() {
 }
 
 func (s *StorageTestSuite) TestBlobLogsByProvidersWithoutJoins() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, sortBy := range []string{"", "time", "size"} {
@@ -376,7 +376,7 @@ func (s *StorageTestSuite) TestBlobLogsByProvidersWithoutJoins() {
 }
 
 func (s *StorageTestSuite) TestBlobLogsExportByProviders() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	buf := new(bytes.Buffer)
@@ -403,7 +403,7 @@ func (s *StorageTestSuite) TestBlobLogsExportByProviders() {
 }
 
 func (s *StorageTestSuite) TestBlob() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	log, err := s.storage.BlobLogs.Blob(ctx, 0, 2, "RWW7eaKKXasSGK/DS8PlpErARbl5iFs1vQIycYEAlk0=")
@@ -427,7 +427,7 @@ func (s *StorageTestSuite) TestBlob() {
 }
 
 func (s *StorageTestSuite) TestListBlob() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	logs, err := s.storage.BlobLogs.ListBlobs(ctx, storage.ListBlobLogFilters{

--- a/internal/storage/postgres/block_signature_test.go
+++ b/internal/storage/postgres/block_signature_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestBlockSignatureLevels() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	levels, err := s.storage.BlockSignatures.LevelsByValidator(ctx, 1, 998)

--- a/internal/storage/postgres/block_stats_test.go
+++ b/internal/storage/postgres/block_stats_test.go
@@ -27,7 +27,7 @@ type BlockStatsTestSuite struct {
 
 // SetupSuite -
 func (s *BlockStatsTestSuite) SetupSuite() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 180*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 180*time.Second)
 	defer ctxCancel()
 
 	psqlContainer, err := testhelpers.NewPostgreSQLContainer(ctx, testhelpers.PostgreSQLContainerConfig{
@@ -39,6 +39,11 @@ func (s *BlockStatsTestSuite) SetupSuite() {
 	})
 	s.Require().NoError(err)
 	s.psqlContainer = psqlContainer
+	s.T().Cleanup(func() {
+		ctx, ctxCancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer ctxCancel()
+		s.Require().NoError(s.psqlContainer.Terminate(ctx))
+	})
 
 	strg, err := Create(ctx, config.Database{
 		Kind:     config.DBKindPostgres,
@@ -50,6 +55,9 @@ func (s *BlockStatsTestSuite) SetupSuite() {
 	}, "../../../database", false)
 	s.Require().NoError(err)
 	s.storage = strg
+	s.T().Cleanup(func() {
+		s.Require().NoError(s.storage.Close())
+	})
 
 	db, err := sql.Open("pgx", s.psqlContainer.GetDSN())
 	s.Require().NoError(err)
@@ -63,15 +71,6 @@ func (s *BlockStatsTestSuite) SetupSuite() {
 	s.Require().NoError(err)
 	s.Require().NoError(fixtures.Load())
 	s.Require().NoError(db.Close())
-}
-
-// TearDownSuite -
-func (s *BlockStatsTestSuite) TearDownSuite() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer ctxCancel()
-
-	s.Require().NoError(s.storage.Close())
-	s.Require().NoError(s.psqlContainer.Terminate(ctx))
 }
 
 func (s *BlockStatsTestSuite) TestByHeight() {
@@ -100,7 +99,7 @@ func (s *BlockStatsTestSuite) TestByHeight() {
 		},
 	}
 
-	ctx, cancelCtx := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancelCtx := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer cancelCtx()
 
 	for _, tt := range tests {
@@ -115,7 +114,7 @@ func (s *BlockStatsTestSuite) TestByHeight() {
 }
 
 func (s *BlockStatsTestSuite) TestLastFrom() {
-	ctx, cancelCtx := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancelCtx := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer cancelCtx()
 
 	got, err := s.storage.BlockStats.LastFrom(ctx, 999, 1)

--- a/internal/storage/postgres/block_test.go
+++ b/internal/storage/postgres/block_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestBlockLast() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	block, err := s.storage.Blocks.Last(ctx)
@@ -31,7 +31,7 @@ func (s *StorageTestSuite) TestBlockLast() {
 }
 
 func (s *StorageTestSuite) TestBlockByHeight() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	block, err := s.storage.Blocks.ByHeight(ctx, 1000)
@@ -48,7 +48,7 @@ func (s *StorageTestSuite) TestBlockByHeight() {
 }
 
 func (s *StorageTestSuite) TestBlockByHeightWithStats() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	block, err := s.storage.Blocks.ByHeightWithStats(ctx, 1000)
@@ -87,7 +87,7 @@ func (s *StorageTestSuite) TestBlockByHeightWithStats() {
 }
 
 func (s *StorageTestSuite) TestBlockByIdWithRelations() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	block, err := s.storage.Blocks.ByIdWithRelations(ctx, 2)
@@ -126,7 +126,7 @@ func (s *StorageTestSuite) TestBlockByIdWithRelations() {
 }
 
 func (s *StorageTestSuite) TestBlockByHash() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	hash, err := hex.DecodeString("6A30C94091DA7C436D64E62111D6890D772E351823C41496B4E52F28F5B000BF")
@@ -143,7 +143,7 @@ func (s *StorageTestSuite) TestBlockByHash() {
 }
 
 func (s *StorageTestSuite) TestBlockListWithStats() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	blocks, err := s.storage.Blocks.ListWithStats(ctx, 10, 0, sdk.SortOrderDesc)
@@ -161,7 +161,7 @@ func (s *StorageTestSuite) TestBlockListWithStats() {
 }
 
 func (s *StorageTestSuite) TestBlockListWithStatsAsc() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	blocks, err := s.storage.Blocks.ListWithStats(ctx, 10, 0, sdk.SortOrderAsc)
@@ -179,7 +179,7 @@ func (s *StorageTestSuite) TestBlockListWithStatsAsc() {
 }
 
 func (s *StorageTestSuite) TestBlockByProposer() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	blocks, err := s.storage.Blocks.ByProposer(ctx, 1, 10, 0)
@@ -197,7 +197,7 @@ func (s *StorageTestSuite) TestBlockByProposer() {
 }
 
 func (s *StorageTestSuite) TestBlockTime() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	expected, err := time.Parse(time.RFC3339, "2023-07-04T03:10:57Z")

--- a/internal/storage/postgres/core_test.go
+++ b/internal/storage/postgres/core_test.go
@@ -28,6 +28,11 @@ func TestCheckDatabaseExists(t *testing.T) {
 
 	psqlContainer, err := testhelpers.NewPostgreSQLContainer(ctx, containerCfg)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		ctx, ctxCancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer ctxCancel()
+		require.NoError(t, psqlContainer.Terminate(ctx))
+	})
 
 	cfg := config.Database{
 		Kind:     config.DBKindPostgres,
@@ -41,19 +46,21 @@ func TestCheckDatabaseExists(t *testing.T) {
 	db := database.NewBun()
 	err = db.Connect(ctx, cfg)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
 
 	exists, err := checkTablesExists(ctx, db)
 	require.NoError(t, err)
 	require.False(t, exists)
-	require.NoError(t, db.Close())
 
 	strg, err := Create(ctx, cfg, "../../../database", false)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, strg.Close())
+	})
 
 	exists, err = checkTablesExists(ctx, strg.Connection())
 	require.NoError(t, err)
 	require.True(t, exists)
-
-	require.NoError(t, strg.Close())
-	require.NoError(t, psqlContainer.Terminate(ctx))
 }

--- a/internal/storage/postgres/delegation_test.go
+++ b/internal/storage/postgres/delegation_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestDelegationByAddress() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	delegations, err := s.storage.Delegation.ByAddress(ctx, 1, 10, 0, false)
@@ -27,7 +27,7 @@ func (s *StorageTestSuite) TestDelegationByAddress() {
 }
 
 func (s *StorageTestSuite) TestDelegationByValidator() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	delegations, err := s.storage.Delegation.ByValidator(ctx, 1, 10, 0, true)

--- a/internal/storage/postgres/event_test.go
+++ b/internal/storage/postgres/event_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestEventByTxId() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	events, err := s.storage.Event.ByTxId(ctx, 1, storage.EventFilter{
@@ -27,7 +27,7 @@ func (s *StorageTestSuite) TestEventByTxId() {
 }
 
 func (s *StorageTestSuite) TestEventByBlock() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	events, err := s.storage.Event.ByBlock(ctx, 1000, storage.EventFilter{

--- a/internal/storage/postgres/export_test.go
+++ b/internal/storage/postgres/export_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestExportToCsv() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	query := s.storage.

--- a/internal/storage/postgres/forwarding_test.go
+++ b/internal/storage/postgres/forwarding_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestForwardingById() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	fwd, prevTime, err := s.storage.Forwardings.ById(ctx, 2)
@@ -37,7 +37,7 @@ func (s *StorageTestSuite) TestForwardingById() {
 }
 
 func (s *StorageTestSuite) TestForwardingByHeight() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	forwards, err := s.storage.Forwardings.Filter(ctx, storage.ForwardingFilter{
@@ -65,7 +65,7 @@ func (s *StorageTestSuite) TestForwardingByHeight() {
 }
 
 func (s *StorageTestSuite) TestForwardingByTxId() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	forwards, err := s.storage.Forwardings.Filter(ctx, storage.ForwardingFilter{
@@ -93,7 +93,7 @@ func (s *StorageTestSuite) TestForwardingByTxId() {
 }
 
 func (s *StorageTestSuite) TestForwardingByAddressId() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	forwards, err := s.storage.Forwardings.Filter(ctx, storage.ForwardingFilter{
@@ -121,7 +121,7 @@ func (s *StorageTestSuite) TestForwardingByAddressId() {
 }
 
 func (s *StorageTestSuite) TestForwardingByFrom() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	forwards, err := s.storage.Forwardings.Filter(ctx, storage.ForwardingFilter{
@@ -149,7 +149,7 @@ func (s *StorageTestSuite) TestForwardingByFrom() {
 }
 
 func (s *StorageTestSuite) TestForwardingByTo() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	forwards, err := s.storage.Forwardings.Filter(ctx, storage.ForwardingFilter{
@@ -177,7 +177,7 @@ func (s *StorageTestSuite) TestForwardingByTo() {
 }
 
 func (s *StorageTestSuite) TestForwardingInputs() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	inputs, err := s.storage.Forwardings.Inputs(ctx, 5, time.Unix(1600000000, 0), time.Unix(1771334044, 0))
@@ -198,7 +198,7 @@ func (s *StorageTestSuite) TestForwardingInputs() {
 // An incorrect ORDER BY in the outer query (using Order instead of OrderExpr) would
 // cause PostgreSQL to return rows in heap order, yielding id=2 instead of id=3.
 func (s *StorageTestSuite) TestForwardingByIdCorrectRecord() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	// id=3 is at '2024-07-04T03:07:00' — 7 minutes after ids 1 and 2.
@@ -214,7 +214,7 @@ func (s *StorageTestSuite) TestForwardingByIdCorrectRecord() {
 // TestForwardingByIdNotFound verifies that requesting a non-existent forwarding id
 // returns sql.ErrNoRows instead of silently returning a record with a lower id.
 func (s *StorageTestSuite) TestForwardingByIdNotFound() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	// id=4 does not exist in the forwarding fixture (only 1, 2, 3 exist).
@@ -227,7 +227,7 @@ func (s *StorageTestSuite) TestForwardingByIdNotFound() {
 // equals the upper bound is included in the inputs list.
 // This requires a non-strict (<=) comparison; a strict (<) would exclude it.
 func (s *StorageTestSuite) TestForwardingInputsAtSameTime() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	// hl_transfer fixture id=3: type=receive, address_id=5, time='2023-07-04T04:11:57', counterparty=123450.

--- a/internal/storage/postgres/grant_test.go
+++ b/internal/storage/postgres/grant_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestGrantByGrantee() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	grants, err := s.storage.Grants.ByGrantee(ctx, 1, 10, 0)
@@ -28,7 +28,7 @@ func (s *StorageTestSuite) TestGrantByGrantee() {
 }
 
 func (s *StorageTestSuite) TestGrantByGranter() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	grants, err := s.storage.Grants.ByGranter(ctx, 2, 10, 0)

--- a/internal/storage/postgres/hl_gas_payment_test.go
+++ b/internal/storage/postgres/hl_gas_payment_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestHyperlaneGasPaymentList() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.HLGasPayment.List(ctx, 10, 0)

--- a/internal/storage/postgres/hl_igp_config_test.go
+++ b/internal/storage/postgres/hl_igp_config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestHyperlaneIgpConfigList() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.HLIGPConfig.List(ctx, 10, 0)

--- a/internal/storage/postgres/hl_igp_test.go
+++ b/internal/storage/postgres/hl_igp_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestHyperlaneIgpByHash() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	igp, err := s.storage.HLIGP.ByHash(ctx, []byte("igp_1"))
@@ -28,7 +28,7 @@ func (s *StorageTestSuite) TestHyperlaneIgpByHash() {
 }
 
 func (s *StorageTestSuite) TestHyperlaneIgpList() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.HLIGP.List(ctx, 10, 0)

--- a/internal/storage/postgres/hl_mailbox_test.go
+++ b/internal/storage/postgres/hl_mailbox_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestHyperlaneMailboxByHash() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	mailbox, err := s.storage.HLMailbox.ByHash(ctx, []byte("mailbox"))
@@ -37,7 +37,7 @@ func (s *StorageTestSuite) TestHyperlaneMailboxByHash() {
 }
 
 func (s *StorageTestSuite) TestHyperlaneMailboxList() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.HLMailbox.List(ctx, 1, 0)

--- a/internal/storage/postgres/hl_token_test.go
+++ b/internal/storage/postgres/hl_token_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestHyperlaneTokenByHash() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	token, err := s.storage.HLToken.ByHash(ctx, []byte("token"))
@@ -44,7 +44,7 @@ func (s *StorageTestSuite) TestHyperlaneTokenByHash() {
 }
 
 func (s *StorageTestSuite) TestHyperlaneTokenList() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tokens, err := s.storage.HLToken.List(ctx, storage.ListHyperlaneTokens{

--- a/internal/storage/postgres/hl_transfer_test.go
+++ b/internal/storage/postgres/hl_transfer_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestHyperlaneTransferList() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, fltrs := range []storage.ListHyperlaneTransferFilters{
@@ -107,7 +107,7 @@ func (s *StorageTestSuite) TestHyperlaneTransferList() {
 }
 
 func (s *StorageTestSuite) TestHyperlaneTransferById() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	transfer, err := s.storage.HLTransfer.ById(ctx, 1)
@@ -128,7 +128,7 @@ func (s *StorageTestSuite) TestHyperlaneTransferById() {
 }
 
 func (s *StorageTestSuite) TestHyperlaneTransferByIdNotFound() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.HLTransfer.ById(ctx, 100000)
@@ -136,7 +136,7 @@ func (s *StorageTestSuite) TestHyperlaneTransferByIdNotFound() {
 }
 
 func (s *StorageTestSuite) TestHlTransferSeries() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	type args struct {
@@ -207,7 +207,7 @@ func (s *StorageTestSuite) TestHlTransferSeries() {
 }
 
 func (s *StorageTestSuite) TestStatsByDomain() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	stats, err := s.storage.HLTransfer.StatsByDomain(ctx, 10, 0)
@@ -220,7 +220,7 @@ func (s *StorageTestSuite) TestStatsByDomain() {
 }
 
 func (s *StorageTestSuite) TestHlTotalSeries() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	type args struct {

--- a/internal/storage/postgres/ibc_channel_test.go
+++ b/internal/storage/postgres/ibc_channel_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestIbcChannelById() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	channel, err := s.storage.IbcChannels.ById(ctx, "channel-1")
@@ -52,7 +52,7 @@ func (s *StorageTestSuite) TestIbcChannelById() {
 }
 
 func (s *StorageTestSuite) TestIbcChannelList() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, fltrs := range []storage.ListChannelFilters{
@@ -122,7 +122,7 @@ func (s *StorageTestSuite) TestIbcChannelList() {
 }
 
 func (s *StorageTestSuite) TestIbcChannelStatsByChainId() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	stats, err := s.storage.IbcChannels.StatsByChain(ctx, 10, 0)
@@ -135,7 +135,7 @@ func (s *StorageTestSuite) TestIbcChannelStatsByChainId() {
 }
 
 func (s *StorageTestSuite) TestIbcBusiestChannel1m() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	channel, err := s.storage.IbcChannels.BusiestChannel1m(ctx)

--- a/internal/storage/postgres/ibc_client_test.go
+++ b/internal/storage/postgres/ibc_client_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestIbcClientById() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	client, err := s.storage.IbcClients.ById(ctx, "client-1")
@@ -34,7 +34,7 @@ func (s *StorageTestSuite) TestIbcClientById() {
 }
 
 func (s *StorageTestSuite) TestIbcClientList() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	clients, err := s.storage.IbcClients.List(ctx, storage.ListIbcClientsFilters{
@@ -62,7 +62,7 @@ func (s *StorageTestSuite) TestIbcClientList() {
 }
 
 func (s *StorageTestSuite) TestIbcClientByChainId() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	clients, err := s.storage.IbcClients.ByChainId(ctx, "osmosis-1")

--- a/internal/storage/postgres/ibc_connection_test.go
+++ b/internal/storage/postgres/ibc_connection_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestIbcConnectionById() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	conn, err := s.storage.IbcConnections.ById(ctx, "connection-1")
@@ -45,7 +45,7 @@ func (s *StorageTestSuite) TestIbcConnectionById() {
 }
 
 func (s *StorageTestSuite) TestIbcConnectionIdsByClients() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	conn, err := s.storage.IbcConnections.IdsByClients(ctx, "client-1")
@@ -55,7 +55,7 @@ func (s *StorageTestSuite) TestIbcConnectionIdsByClients() {
 }
 
 func (s *StorageTestSuite) TestIbcConnectionList() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, fltrs := range []storage.ListConnectionFilters{

--- a/internal/storage/postgres/ibc_transfer_test.go
+++ b/internal/storage/postgres/ibc_transfer_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestIbcTransferList() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, fltrs := range []storage.ListIbcTransferFilters{
@@ -80,7 +80,7 @@ func (s *StorageTestSuite) TestIbcTransferList() {
 }
 
 func (s *StorageTestSuite) TestIbcTransferSeries() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	type args struct {
@@ -151,7 +151,7 @@ func (s *StorageTestSuite) TestIbcTransferSeries() {
 }
 
 func (s *StorageTestSuite) TestIbcLargestTransfer24h() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	transfer, err := s.storage.IbcTransfers.LargestTransfer24h(ctx)
@@ -170,7 +170,7 @@ func (s *StorageTestSuite) TestIbcLargestTransfer24h() {
 }
 
 func (s *StorageTestSuite) TestIbcTransferById() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	transfer, err := s.storage.IbcTransfers.ById(ctx, 3)
@@ -190,7 +190,7 @@ func (s *StorageTestSuite) TestIbcTransferById() {
 }
 
 func (s *StorageTestSuite) TestIbcTransferByIdNotFound() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.IbcTransfers.ById(ctx, 100000)

--- a/internal/storage/postgres/jail_test.go
+++ b/internal/storage/postgres/jail_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestJailByValidator() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	jails, err := s.storage.Jails.ByValidator(ctx, 1, 10, 0)

--- a/internal/storage/postgres/redelegation_test.go
+++ b/internal/storage/postgres/redelegation_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestRedelegationByAddress() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	redelegations, err := s.storage.Redelegation.ByAddress(ctx, 1, 10, 0)

--- a/internal/storage/postgres/rollup_provider_test.go
+++ b/internal/storage/postgres/rollup_provider_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestRollupProviderByRollupId() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	providers, err := s.storage.RollupProvider.ByRollupId(ctx, 1)

--- a/internal/storage/postgres/rollup_test.go
+++ b/internal/storage/postgres/rollup_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestRollupLeaderboard() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.Connection().Exec(ctx, "REFRESH MATERIALIZED VIEW leaderboard;")
@@ -50,7 +50,7 @@ func (s *StorageTestSuite) TestRollupLeaderboard() {
 }
 
 func (s *StorageTestSuite) TestRollupLeaderboardWithCategory() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.Connection().Exec(ctx, "REFRESH MATERIALIZED VIEW leaderboard;")
@@ -90,7 +90,7 @@ func (s *StorageTestSuite) TestRollupLeaderboardWithCategory() {
 }
 
 func (s *StorageTestSuite) TestRollupLeaderboardWithTags() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.Connection().Exec(ctx, "REFRESH MATERIALIZED VIEW leaderboard;")
@@ -130,7 +130,7 @@ func (s *StorageTestSuite) TestRollupLeaderboardWithTags() {
 }
 
 func (s *StorageTestSuite) TestRollupLeaderboardWithType() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.Connection().Exec(ctx, "REFRESH MATERIALIZED VIEW leaderboard;")
@@ -168,7 +168,7 @@ func (s *StorageTestSuite) TestRollupLeaderboardWithType() {
 }
 
 func (s *StorageTestSuite) TestRollupLeaderboardWithStack() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.Connection().Exec(ctx, "REFRESH MATERIALIZED VIEW leaderboard;")
@@ -205,7 +205,7 @@ func (s *StorageTestSuite) TestRollupLeaderboardWithStack() {
 }
 
 func (s *StorageTestSuite) TestRollupLeaderboardWithProvider() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.Connection().Exec(ctx, "REFRESH MATERIALIZED VIEW leaderboard;")
@@ -242,7 +242,7 @@ func (s *StorageTestSuite) TestRollupLeaderboardWithProvider() {
 }
 
 func (s *StorageTestSuite) TestRollupLeaderboardDay() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.Connection().Exec(ctx, "REFRESH MATERIALIZED VIEW leaderboard_day;")
@@ -264,7 +264,7 @@ func (s *StorageTestSuite) TestRollupLeaderboardDay() {
 }
 
 func (s *StorageTestSuite) TestRollupNamespaces() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	nsIds, err := s.storage.Rollup.Namespaces(ctx, 1, 10, 0)
@@ -273,7 +273,7 @@ func (s *StorageTestSuite) TestRollupNamespaces() {
 }
 
 func (s *StorageTestSuite) TestRollupProviders() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	providers, err := s.storage.Rollup.Providers(ctx, 1)
@@ -282,7 +282,7 @@ func (s *StorageTestSuite) TestRollupProviders() {
 }
 
 func (s *StorageTestSuite) TestRollupSeries() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, tf := range []storage.Timeframe{
@@ -302,7 +302,7 @@ func (s *StorageTestSuite) TestRollupSeries() {
 }
 
 func (s *StorageTestSuite) TestRollupBySlug() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.Connection().Exec(ctx, "REFRESH MATERIALIZED VIEW leaderboard;")
@@ -327,7 +327,7 @@ func (s *StorageTestSuite) TestRollupBySlug() {
 }
 
 func (s *StorageTestSuite) TestRollupById() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.Connection().Exec(ctx, "REFRESH MATERIALIZED VIEW leaderboard;")
@@ -352,7 +352,7 @@ func (s *StorageTestSuite) TestRollupById() {
 }
 
 func (s *StorageTestSuite) TestRollupsByNamespace() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	rollups, err := s.storage.Rollup.RollupsByNamespace(ctx, 2, 10, 0)
@@ -365,7 +365,7 @@ func (s *StorageTestSuite) TestRollupsByNamespace() {
 }
 
 func (s *StorageTestSuite) TestRollupDistribution() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, groupBy := range []storage.Timeframe{
@@ -383,7 +383,7 @@ func (s *StorageTestSuite) TestRollupDistribution() {
 }
 
 func (s *StorageTestSuite) TestRollupAllSeries() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, tf := range []storage.Timeframe{
@@ -395,7 +395,7 @@ func (s *StorageTestSuite) TestRollupAllSeries() {
 }
 
 func (s *StorageTestSuite) TestRollupStatsGrouping() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.Connection().Exec(ctx, "REFRESH MATERIALIZED VIEW leaderboard;")
@@ -417,7 +417,7 @@ func (s *StorageTestSuite) TestRollupStatsGrouping() {
 }
 
 func (s *StorageTestSuite) TestRollupTags() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tags, err := s.storage.Rollup.Tags(ctx)
@@ -428,7 +428,7 @@ func (s *StorageTestSuite) TestRollupTags() {
 }
 
 func (s *StorageTestSuite) TestCount() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	count, err := s.storage.Rollup.Count(ctx)
@@ -437,7 +437,7 @@ func (s *StorageTestSuite) TestCount() {
 }
 
 func (s *StorageTestSuite) TestUnverified() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	rollups, err := s.storage.Rollup.Unverified(ctx)

--- a/internal/storage/postgres/search_test.go
+++ b/internal/storage/postgres/search_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestSearchText() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	results, err := s.storage.Search.SearchText(ctx, "con")
@@ -24,7 +24,7 @@ func (s *StorageTestSuite) TestSearchText() {
 }
 
 func (s *StorageTestSuite) TestSearchTextNamespace() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	results, err := s.storage.Search.SearchText(ctx, "5F7A8DDFE6136FE76B65B9066D4F816D707F")
@@ -38,7 +38,7 @@ func (s *StorageTestSuite) TestSearchTextNamespace() {
 }
 
 func (s *StorageTestSuite) TestSearch() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	hash, err := hex.DecodeString("5F7A8DDFE6136FE76B65B9066D4F816D707F28C05B3362D66084664C5B39BA98")
@@ -55,7 +55,7 @@ func (s *StorageTestSuite) TestSearch() {
 }
 
 func (s *StorageTestSuite) TestSearchByDataHash() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	hash, err := hex.DecodeString("3D96B7D238E7E0456F6AF8E7CDF0A67BD6CF9C2089ECB559C659DCAA1F880353")
@@ -72,7 +72,7 @@ func (s *StorageTestSuite) TestSearchByDataHash() {
 }
 
 func (s *StorageTestSuite) TestSearchByTextByCelestials() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	results, err := s.storage.Search.SearchText(ctx, "me 1")

--- a/internal/storage/postgres/signal_version_test.go
+++ b/internal/storage/postgres/signal_version_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestSignalVersionList() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, fltrs := range []storage.ListSignalsFilter{

--- a/internal/storage/postgres/stats_test.go
+++ b/internal/storage/postgres/stats_test.go
@@ -26,7 +26,7 @@ type StatsTestSuite struct {
 
 // SetupSuite -
 func (s *StatsTestSuite) SetupSuite() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 180*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 180*time.Second)
 	defer ctxCancel()
 
 	psqlContainer, err := testhelpers.NewPostgreSQLContainer(ctx, testhelpers.PostgreSQLContainerConfig{
@@ -38,6 +38,11 @@ func (s *StatsTestSuite) SetupSuite() {
 	})
 	s.Require().NoError(err)
 	s.psqlContainer = psqlContainer
+	s.T().Cleanup(func() {
+		ctx, ctxCancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer ctxCancel()
+		s.Require().NoError(s.psqlContainer.Terminate(ctx))
+	})
 
 	strg, err := Create(ctx, config.Database{
 		Kind:     config.DBKindPostgres,
@@ -49,6 +54,9 @@ func (s *StatsTestSuite) SetupSuite() {
 	}, "../../../database", false)
 	s.Require().NoError(err)
 	s.storage = strg
+	s.T().Cleanup(func() {
+		s.Require().NoError(s.storage.Close())
+	})
 
 	db, err := sql.Open("pgx", s.psqlContainer.GetDSN())
 	s.Require().NoError(err)
@@ -62,15 +70,6 @@ func (s *StatsTestSuite) SetupSuite() {
 	s.Require().NoError(err)
 	s.Require().NoError(fixtures.Load())
 	s.Require().NoError(db.Close())
-}
-
-// TearDownSuite -
-func (s *StatsTestSuite) TearDownSuite() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer ctxCancel()
-
-	s.Require().NoError(s.storage.Close())
-	s.Require().NoError(s.psqlContainer.Terminate(ctx))
 }
 
 func (s *StatsTestSuite) TestCount() {
@@ -96,7 +95,7 @@ func (s *StatsTestSuite) TestCount() {
 	}
 
 	for i := range tests {
-		ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 
 		count, err := s.storage.Stats.Count(ctx, storage.CountRequest{
 			Table: tests[i].table,
@@ -127,7 +126,7 @@ func (s *StatsTestSuite) TestCountNoData() {
 	}
 
 	for i := range tests {
-		ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 
 		count, err := s.storage.Stats.Count(ctx, storage.CountRequest{
 			Table: tests[i].table,
@@ -196,7 +195,7 @@ func (s *StatsTestSuite) TestSummaryBlock() {
 	}
 
 	for i := range tests {
-		ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 
 		summary, err := s.storage.Stats.Summary(ctx, storage.SummaryRequest{
 			CountRequest: storage.CountRequest{
@@ -216,7 +215,7 @@ func (s *StatsTestSuite) TestSummaryBlock() {
 }
 
 func (s *StatsTestSuite) TestTPS() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tps, err := s.storage.Stats.TPS(ctx)
@@ -229,7 +228,7 @@ func (s *StatsTestSuite) TestTPS() {
 }
 
 func (s *StatsTestSuite) TestSeries() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.Stats.Series(ctx, storage.TimeframeHour, storage.SeriesBlobsSize, storage.SeriesRequest{})
@@ -238,7 +237,7 @@ func (s *StatsTestSuite) TestSeries() {
 }
 
 func (s *StatsTestSuite) TestSeriesWithFrom() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.Stats.Series(ctx, storage.TimeframeDay, storage.SeriesBlobsSize, storage.SeriesRequest{
@@ -249,7 +248,7 @@ func (s *StatsTestSuite) TestSeriesWithFrom() {
 }
 
 func (s *StatsTestSuite) TestCumulativeSeries() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.Stats.CumulativeSeries(ctx, storage.TimeframeDay, storage.SeriesBlobsSize, storage.SeriesRequest{})
@@ -258,7 +257,7 @@ func (s *StatsTestSuite) TestCumulativeSeries() {
 }
 
 func (s *StatsTestSuite) TestCumulativeSeriesWithFrom() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.Stats.CumulativeSeries(ctx, storage.TimeframeDay, storage.SeriesBlobsSize, storage.SeriesRequest{
@@ -269,7 +268,7 @@ func (s *StatsTestSuite) TestCumulativeSeriesWithFrom() {
 }
 
 func (s *StatsTestSuite) TestNamespaceSeries() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.Stats.NamespaceSeries(ctx, storage.TimeframeHour, storage.SeriesNsSize, 1, storage.SeriesRequest{})
@@ -278,7 +277,7 @@ func (s *StatsTestSuite) TestNamespaceSeries() {
 }
 
 func (s *StatsTestSuite) TestSquareSize() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	from := time.Date(2023, 7, 1, 0, 0, 0, 0, time.UTC)
@@ -288,7 +287,7 @@ func (s *StatsTestSuite) TestSquareSize() {
 }
 
 func (s *StatsTestSuite) TestRollupStats24h() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	stats, err := s.storage.Stats.RollupStats24h(ctx)
@@ -297,7 +296,7 @@ func (s *StatsTestSuite) TestRollupStats24h() {
 }
 
 func (s *StatsTestSuite) TestMessagesCount24h() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.Stats.MessagesCount24h(ctx)
@@ -306,7 +305,7 @@ func (s *StatsTestSuite) TestMessagesCount24h() {
 }
 
 func (s *StatsTestSuite) TestChange24hBlockStats() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	stats, err := s.storage.Stats.Change24hBlockStats(ctx)
@@ -318,7 +317,7 @@ func (s *StatsTestSuite) TestChange24hBlockStats() {
 }
 
 func (s *StatsTestSuite) TestSizeGroups() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tf := time.Now().UTC().AddDate(-25, 0, 0)
@@ -349,7 +348,7 @@ func (s *StatsTestSuite) TestStakingSeries() {
 			storage.SeriesFlow,
 			storage.SeriesCumulativeFlow,
 		} {
-			ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 			defer ctxCancel()
 
 			items, err := s.storage.Stats.StakingSeries(ctx, tf, series, 1, storage.NewSeriesRequest(0, 0))
@@ -360,7 +359,7 @@ func (s *StatsTestSuite) TestStakingSeries() {
 }
 
 func (s *StatsTestSuite) TestStakingDistribution() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.Stats.StakingDistribution(ctx, storage.NewSeriesRequest(0, 0))

--- a/internal/storage/postgres/storage_test.go
+++ b/internal/storage/postgres/storage_test.go
@@ -31,7 +31,7 @@ type StorageTestSuite struct {
 
 // SetupSuite -
 func (s *StorageTestSuite) SetupSuite() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 180*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 180*time.Second)
 	defer ctxCancel()
 
 	psqlContainer, err := testhelpers.NewPostgreSQLContainer(ctx, testhelpers.PostgreSQLContainerConfig{
@@ -43,6 +43,11 @@ func (s *StorageTestSuite) SetupSuite() {
 	})
 	s.Require().NoError(err)
 	s.psqlContainer = psqlContainer
+	s.T().Cleanup(func() {
+		ctx, ctxCancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer ctxCancel()
+		s.Require().NoError(s.psqlContainer.Terminate(ctx))
+	})
 
 	strg, err := Create(ctx, config.Database{
 		Kind:     config.DBKindPostgres,
@@ -54,6 +59,9 @@ func (s *StorageTestSuite) SetupSuite() {
 	}, "../../../database", false)
 	s.Require().NoError(err)
 	s.storage = strg
+	s.T().Cleanup(func() {
+		s.Require().NoError(s.storage.Close())
+	})
 
 	db, err := sql.Open("pgx", s.psqlContainer.GetDSN())
 	s.Require().NoError(err)
@@ -69,17 +77,8 @@ func (s *StorageTestSuite) SetupSuite() {
 	s.Require().NoError(db.Close())
 }
 
-// TearDownSuite -
-func (s *StorageTestSuite) TearDownSuite() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer ctxCancel()
-
-	s.Require().NoError(s.storage.Close())
-	s.Require().NoError(s.psqlContainer.Terminate(ctx))
-}
-
 func (s *StorageTestSuite) TestStateGetByName() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	state, err := s.storage.State.ByName(ctx, testIndexerName)
@@ -94,7 +93,7 @@ func (s *StorageTestSuite) TestStateGetByName() {
 }
 
 func (s *StorageTestSuite) TestStateGetByNameFailed() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.State.ByName(ctx, "unknown")
@@ -102,7 +101,7 @@ func (s *StorageTestSuite) TestStateGetByNameFailed() {
 }
 
 func (s *StorageTestSuite) TestMessageByTxId() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	msgs, err := s.storage.Message.ByTxId(ctx, 1, 1, 0)
@@ -115,7 +114,7 @@ func (s *StorageTestSuite) TestMessageByTxId() {
 }
 
 func (s *StorageTestSuite) TestMessageListWithTx() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	msgs, err := s.storage.Message.ListWithTx(ctx, storage.MessageListWithTxFilters{
@@ -155,7 +154,7 @@ func (s *StorageTestSuite) TestMessageListWithTx() {
 }
 
 func (s *StorageTestSuite) TestNamespaceId() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	namespaceId, err := hex.DecodeString("5F7A8DDFE6136FE76B65B9066D4F816D707F")
@@ -177,7 +176,7 @@ func (s *StorageTestSuite) TestNamespaceId() {
 }
 
 func (s *StorageTestSuite) TestNamespaceIdAndVersion() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	namespaceId, err := hex.DecodeString("5F7A8DDFE6136FE76B65B9066D4F816D707F")
@@ -193,7 +192,7 @@ func (s *StorageTestSuite) TestNamespaceIdAndVersion() {
 }
 
 func (s *StorageTestSuite) TestNamespaceMessages() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	msgs, err := s.storage.Namespace.Messages(ctx, 2, 10, 0)
@@ -211,7 +210,7 @@ func (s *StorageTestSuite) TestNamespaceMessages() {
 }
 
 func (s *StorageTestSuite) TestNamespaceActive() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	ns, err := s.storage.Namespace.ListWithSort(ctx, "", sdk.SortOrderDesc, 2, 0)
@@ -225,7 +224,7 @@ func (s *StorageTestSuite) TestNamespaceActive() {
 }
 
 func (s *StorageTestSuite) TestNamespaceActiveByPfbCount() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	ns, err := s.storage.Namespace.ListWithSort(ctx, pfbCountColumn, sdk.SortOrderDesc, 2, 0)
@@ -239,7 +238,7 @@ func (s *StorageTestSuite) TestNamespaceActiveByPfbCount() {
 }
 
 func (s *StorageTestSuite) TestNamespaceActiveBySize() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	ns, err := s.storage.Namespace.ListWithSort(ctx, "size", sdk.SortOrderDesc, 2, 0)
@@ -253,7 +252,7 @@ func (s *StorageTestSuite) TestNamespaceActiveBySize() {
 }
 
 func (s *StorageTestSuite) TestNamespaceGetByIds() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	ns, err := s.storage.Namespace.GetByIds(ctx, 1, 2, 3)
@@ -262,7 +261,7 @@ func (s *StorageTestSuite) TestNamespaceGetByIds() {
 }
 
 func (s *StorageTestSuite) TestConstantGet() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	c, err := s.storage.Constants.Get(ctx, types.ModuleNameBlob, "gas_per_blob_byte")
@@ -272,7 +271,7 @@ func (s *StorageTestSuite) TestConstantGet() {
 }
 
 func (s *StorageTestSuite) TestConstantByModule() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	c, err := s.storage.Constants.ByModule(ctx, types.ModuleNameAuth)
@@ -284,7 +283,7 @@ func (s *StorageTestSuite) TestConstantByModule() {
 }
 
 func (s *StorageTestSuite) TestDenomMetadata() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	metadata, err := s.storage.DenomMetadata.All(ctx)
@@ -301,7 +300,7 @@ func (s *StorageTestSuite) TestDenomMetadata() {
 }
 
 func (s *StorageTestSuite) TestNotify() {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer cancel()
 
 	err := s.storage.Notificator.Subscribe(ctx, "test")

--- a/internal/storage/postgres/transaction_test.go
+++ b/internal/storage/postgres/transaction_test.go
@@ -33,7 +33,7 @@ type TransactionTestSuite struct {
 
 // SetupSuite -
 func (s *TransactionTestSuite) SetupSuite() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 180*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 180*time.Second)
 	defer ctxCancel()
 
 	psqlContainer, err := testhelpers.NewPostgreSQLContainer(ctx, testhelpers.PostgreSQLContainerConfig{
@@ -45,6 +45,11 @@ func (s *TransactionTestSuite) SetupSuite() {
 	})
 	s.Require().NoError(err)
 	s.psqlContainer = psqlContainer
+	s.T().Cleanup(func() {
+		ctx, ctxCancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer ctxCancel()
+		s.Require().NoError(s.psqlContainer.Terminate(ctx))
+	})
 
 	strg, err := Create(ctx, config.Database{
 		Kind:     config.DBKindPostgres,
@@ -56,15 +61,9 @@ func (s *TransactionTestSuite) SetupSuite() {
 	}, "../../../database", false)
 	s.Require().NoError(err)
 	s.storage = strg
-}
-
-// TearDownSuite -
-func (s *TransactionTestSuite) TearDownSuite() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer ctxCancel()
-
-	s.Require().NoError(s.storage.Close())
-	s.Require().NoError(s.psqlContainer.Terminate(ctx))
+	s.T().Cleanup(func() {
+		s.Require().NoError(s.storage.Close())
+	})
 }
 
 func (s *TransactionTestSuite) BeforeTest(suiteName, testName string) {
@@ -83,7 +82,7 @@ func (s *TransactionTestSuite) BeforeTest(suiteName, testName string) {
 }
 
 func (s *TransactionTestSuite) TestSaveNamespaces() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -163,7 +162,7 @@ func (s *TransactionTestSuite) TestSaveNamespaces() {
 }
 
 func (s *TransactionTestSuite) TestSaveAddresses() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -221,7 +220,7 @@ func (s *TransactionTestSuite) TestSaveAddresses() {
 }
 
 func (s *TransactionTestSuite) TestSaveTxAddresses() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -241,7 +240,7 @@ func (s *TransactionTestSuite) TestSaveTxAddresses() {
 }
 
 func (s *TransactionTestSuite) TestSaveMsgAddresses() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -263,7 +262,7 @@ func (s *TransactionTestSuite) TestSaveMsgAddresses() {
 }
 
 func (s *TransactionTestSuite) TestSaveBalances() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -284,7 +283,7 @@ func (s *TransactionTestSuite) TestSaveBalances() {
 }
 
 func (s *TransactionTestSuite) TestSaveNamespaceMessages() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -306,7 +305,7 @@ func (s *TransactionTestSuite) TestSaveNamespaceMessages() {
 }
 
 func (s *TransactionTestSuite) TestSaveBlobLogs() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -330,7 +329,7 @@ func (s *TransactionTestSuite) TestSaveBlobLogs() {
 }
 
 func (s *TransactionTestSuite) TestSaveBlobLogsWithCopy() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -371,7 +370,7 @@ func (s *TransactionTestSuite) TestSaveBlobLogsWithCopy() {
 }
 
 func (s *TransactionTestSuite) TestSaveTransactionsWithCopy() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -420,7 +419,7 @@ func (s *TransactionTestSuite) TestSaveTransactionsWithCopy() {
 }
 
 func (s *TransactionTestSuite) TestSaveMessagesWithCopy() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -460,7 +459,7 @@ func (s *TransactionTestSuite) TestSaveMessagesWithCopy() {
 }
 
 func (s *TransactionTestSuite) TestSaveProposals() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -493,7 +492,7 @@ func (s *TransactionTestSuite) TestSaveProposals() {
 }
 
 func (s *TransactionTestSuite) TestSaveEmptyProposalDuplicate() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -515,7 +514,7 @@ func (s *TransactionTestSuite) TestSaveEmptyProposalDuplicate() {
 }
 
 func (s *TransactionTestSuite) TestSaveVotes() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -555,7 +554,7 @@ func (s *TransactionTestSuite) TestSaveVotes() {
 }
 
 func (s *TransactionTestSuite) TestSave2Votes() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -598,7 +597,7 @@ func (s *TransactionTestSuite) TestSave2Votes() {
 }
 
 func (s *TransactionTestSuite) TestSaveWeightedVotes() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -644,7 +643,7 @@ func (s *TransactionTestSuite) TestSaveWeightedVotes() {
 }
 
 func (s *TransactionTestSuite) TestSaveVotesValidatorIdDuplicate() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -690,7 +689,7 @@ func (s *TransactionTestSuite) TestSaveVotesValidatorIdDuplicate() {
 }
 
 func (s *TransactionTestSuite) TestSaveVotesAddressIdDuplicate() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -736,7 +735,7 @@ func (s *TransactionTestSuite) TestSaveVotesAddressIdDuplicate() {
 }
 
 func (s *TransactionTestSuite) TestSaveBlockSignatures() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -757,7 +756,7 @@ func (s *TransactionTestSuite) TestSaveBlockSignatures() {
 }
 
 func (s *TransactionTestSuite) TestSaveForwardings() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -783,7 +782,7 @@ func (s *TransactionTestSuite) TestSaveForwardings() {
 }
 
 func (s *TransactionTestSuite) TestRollbackBlockSignatures() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -797,7 +796,7 @@ func (s *TransactionTestSuite) TestRollbackBlockSignatures() {
 }
 
 func (s *TransactionTestSuite) TestRollbackBlock() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -816,7 +815,7 @@ func (s *TransactionTestSuite) TestRollbackBlock() {
 }
 
 func (s *TransactionTestSuite) TestRollbackBlockStats() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -832,7 +831,7 @@ func (s *TransactionTestSuite) TestRollbackBlockStats() {
 }
 
 func (s *TransactionTestSuite) TestRollbackAddress() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -851,7 +850,7 @@ func (s *TransactionTestSuite) TestRollbackAddress() {
 }
 
 func (s *TransactionTestSuite) TestRollbackTxs() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -872,7 +871,7 @@ func (s *TransactionTestSuite) TestRollbackTxs() {
 }
 
 func (s *TransactionTestSuite) TestRollbackEvents() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -894,7 +893,7 @@ func (s *TransactionTestSuite) TestRollbackEvents() {
 }
 
 func (s *TransactionTestSuite) TestRollbackMessages() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -917,7 +916,7 @@ func (s *TransactionTestSuite) TestRollbackMessages() {
 }
 
 func (s *TransactionTestSuite) TestRollbackBlobLogs() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -935,7 +934,7 @@ func (s *TransactionTestSuite) TestRollbackBlobLogs() {
 }
 
 func (s *TransactionTestSuite) TestRollbackValidators() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -954,7 +953,7 @@ func (s *TransactionTestSuite) TestRollbackValidators() {
 }
 
 func (s *TransactionTestSuite) TestRollbackNamespaces() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -976,7 +975,7 @@ func (s *TransactionTestSuite) TestRollbackNamespaces() {
 }
 
 func (s *TransactionTestSuite) TestRollbackUndelegations() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -994,7 +993,7 @@ func (s *TransactionTestSuite) TestRollbackUndelegations() {
 }
 
 func (s *TransactionTestSuite) TestRollbackRedelegations() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1012,7 +1011,7 @@ func (s *TransactionTestSuite) TestRollbackRedelegations() {
 }
 
 func (s *TransactionTestSuite) TestRollbackNamespaceMessages() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1042,7 +1041,7 @@ func (s *TransactionTestSuite) TestRollbackNamespaceMessages() {
 }
 
 func (s *TransactionTestSuite) TestRollbackProposals() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1063,7 +1062,7 @@ func (s *TransactionTestSuite) TestRollbackProposals() {
 }
 
 func (s *TransactionTestSuite) TestRollbackVotes() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1081,7 +1080,7 @@ func (s *TransactionTestSuite) TestRollbackVotes() {
 }
 
 func (s *TransactionTestSuite) TestRollbackHyperlaneIgps() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1099,7 +1098,7 @@ func (s *TransactionTestSuite) TestRollbackHyperlaneIgps() {
 }
 
 func (s *TransactionTestSuite) TestRollbackHyperlaneIgpConfigs() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1117,7 +1116,7 @@ func (s *TransactionTestSuite) TestRollbackHyperlaneIgpConfigs() {
 }
 
 func (s *TransactionTestSuite) TestRollbackHyperlaneGasPayment() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1135,7 +1134,7 @@ func (s *TransactionTestSuite) TestRollbackHyperlaneGasPayment() {
 }
 
 func (s *TransactionTestSuite) TestRollbackForwardings() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1153,7 +1152,7 @@ func (s *TransactionTestSuite) TestRollbackForwardings() {
 }
 
 func (s *TransactionTestSuite) TestDeleteBalances() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1167,7 +1166,7 @@ func (s *TransactionTestSuite) TestDeleteBalances() {
 }
 
 func (s *TransactionTestSuite) TestLastAddressAction() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1184,7 +1183,7 @@ func (s *TransactionTestSuite) TestLastAddressAction() {
 }
 
 func (s *TransactionTestSuite) TestSaveEvents() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1224,7 +1223,7 @@ func (s *TransactionTestSuite) TestSaveEvents() {
 }
 
 func (s *TransactionTestSuite) TestSaveEventsWithCopy() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1263,7 +1262,7 @@ func (s *TransactionTestSuite) TestSaveEventsWithCopy() {
 }
 
 func (s *TransactionTestSuite) TestGetProposerId() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1280,7 +1279,7 @@ func (s *TransactionTestSuite) TestGetProposerId() {
 const testLink = "test_link"
 
 func (s *TransactionTestSuite) TestSaveUpdateAndDeleteRollup() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1344,7 +1343,7 @@ func (s *TransactionTestSuite) TestSaveUpdateAndDeleteRollup() {
 }
 
 func (s *TransactionTestSuite) TestRetentionBlockSignatures() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1362,7 +1361,7 @@ func (s *TransactionTestSuite) TestRetentionBlockSignatures() {
 }
 
 func (s *TransactionTestSuite) TestSaveRedelegations() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1392,7 +1391,7 @@ func (s *TransactionTestSuite) TestSaveRedelegations() {
 }
 
 func (s *TransactionTestSuite) TestSaveUndelegations() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1421,7 +1420,7 @@ func (s *TransactionTestSuite) TestSaveUndelegations() {
 }
 
 func (s *TransactionTestSuite) TestSaveDelegations() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1451,7 +1450,7 @@ func (s *TransactionTestSuite) TestSaveDelegations() {
 }
 
 func (s *TransactionTestSuite) TestRetentionCompletedUnbondings() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1468,7 +1467,7 @@ func (s *TransactionTestSuite) TestRetentionCompletedUnbondings() {
 }
 
 func (s *TransactionTestSuite) TestRetentionCompletedRedelegations() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1485,7 +1484,7 @@ func (s *TransactionTestSuite) TestRetentionCompletedRedelegations() {
 }
 
 func (s *TransactionTestSuite) TestJail() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1508,7 +1507,7 @@ func (s *TransactionTestSuite) TestJail() {
 }
 
 func (s *TransactionTestSuite) TestUpdateSlashedDelegations() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1536,7 +1535,7 @@ func (s *TransactionTestSuite) TestUpdateSlashedDelegations() {
 }
 
 func (s *TransactionTestSuite) TestSaveValidators() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1656,7 +1655,7 @@ func (s *TransactionTestSuite) TestSaveValidators() {
 }
 
 func (s *TransactionTestSuite) TestValidators() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1678,7 +1677,7 @@ func (s *TransactionTestSuite) TestValidators() {
 }
 
 func (s *TransactionTestSuite) TestProposalVotes() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1694,7 +1693,7 @@ func (s *TransactionTestSuite) TestProposalVotes() {
 }
 
 func (s *TransactionTestSuite) TestAddressDelegations() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1710,7 +1709,7 @@ func (s *TransactionTestSuite) TestAddressDelegations() {
 }
 
 func (s *TransactionTestSuite) TestUpdateConstants() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1732,7 +1731,7 @@ func (s *TransactionTestSuite) TestUpdateConstants() {
 }
 
 func (s *TransactionTestSuite) TestProposal() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1750,7 +1749,7 @@ func (s *TransactionTestSuite) TestProposal() {
 }
 
 func (s *TransactionTestSuite) TestActiveProposal() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1769,7 +1768,7 @@ func (s *TransactionTestSuite) TestActiveProposal() {
 }
 
 func (s *TransactionTestSuite) TestIbcClients() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1802,7 +1801,7 @@ func (s *TransactionTestSuite) TestIbcClients() {
 }
 
 func (s *TransactionTestSuite) TestIbcConnections() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1837,7 +1836,7 @@ func (s *TransactionTestSuite) TestIbcConnections() {
 }
 
 func (s *TransactionTestSuite) TestIbcChannels() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1881,7 +1880,7 @@ func (s *TransactionTestSuite) TestIbcChannels() {
 }
 
 func (s *TransactionTestSuite) TestIbcTransfers() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1915,7 +1914,7 @@ func (s *TransactionTestSuite) TestIbcTransfers() {
 }
 
 func (s *TransactionTestSuite) TestIbcConnection() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1930,7 +1929,7 @@ func (s *TransactionTestSuite) TestIbcConnection() {
 }
 
 func (s *TransactionTestSuite) TestHyperlaneTransfers() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -1969,7 +1968,7 @@ func (s *TransactionTestSuite) TestHyperlaneTransfers() {
 }
 
 func (s *TransactionTestSuite) TestHyperlaneTokens() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -2005,7 +2004,7 @@ func (s *TransactionTestSuite) TestHyperlaneTokens() {
 }
 
 func (s *TransactionTestSuite) TestHyperlaneMailbox() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -2041,7 +2040,7 @@ func (s *TransactionTestSuite) TestHyperlaneMailbox() {
 }
 
 func (s *TransactionTestSuite) TestGetHyperlaneMailbox() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -2056,7 +2055,7 @@ func (s *TransactionTestSuite) TestGetHyperlaneMailbox() {
 }
 
 func (s *TransactionTestSuite) TestGetHyperlaneToken() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -2071,7 +2070,7 @@ func (s *TransactionTestSuite) TestGetHyperlaneToken() {
 }
 
 func (s *TransactionTestSuite) TestSaveSignals() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -2122,7 +2121,7 @@ func (s *TransactionTestSuite) TestSaveSignals() {
 }
 
 func (s *TransactionTestSuite) TestSaveUpgrades() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -2181,7 +2180,7 @@ func (s *TransactionTestSuite) TestSaveUpgrades() {
 }
 
 func (s *TransactionTestSuite) TestUpdateSignalsAfterUpgrade() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -2206,7 +2205,7 @@ func (s *TransactionTestSuite) TestUpdateSignalsAfterUpgrade() {
 }
 
 func (s *TransactionTestSuite) TestRollbackUpgrade() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -2226,7 +2225,7 @@ func (s *TransactionTestSuite) TestRollbackUpgrade() {
 }
 
 func (s *TransactionTestSuite) TestRollbackSignalVersions() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -2246,7 +2245,7 @@ func (s *TransactionTestSuite) TestRollbackSignalVersions() {
 }
 
 func (s *TransactionTestSuite) TestMsgValidator() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -2274,7 +2273,7 @@ func (s *TransactionTestSuite) TestMsgValidator() {
 }
 
 func (s *TransactionTestSuite) TestSaveHyperlaneIgps() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -2303,7 +2302,7 @@ func (s *TransactionTestSuite) TestSaveHyperlaneIgps() {
 }
 
 func (s *TransactionTestSuite) TestHyperlaneIgp() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -2319,7 +2318,7 @@ func (s *TransactionTestSuite) TestHyperlaneIgp() {
 }
 
 func (s *TransactionTestSuite) TestSaveIgpConfig() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -2350,7 +2349,7 @@ func (s *TransactionTestSuite) TestSaveIgpConfig() {
 }
 
 func (s *TransactionTestSuite) TestHyperlaneIgpConfig() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)
@@ -2369,7 +2368,7 @@ func (s *TransactionTestSuite) TestHyperlaneIgpConfig() {
 }
 
 func (s *TransactionTestSuite) TestSaveHyperlaneGasPayments() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	tx, err := BeginTransaction(ctx, s.storage.Transactable)

--- a/internal/storage/postgres/undelegation_test.go
+++ b/internal/storage/postgres/undelegation_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestUndelegationByAddress() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	undelegations, err := s.storage.Undelegation.ByAddress(ctx, 1, 10, 0)

--- a/internal/storage/postgres/upgrade_test.go
+++ b/internal/storage/postgres/upgrade_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestUpgradeList() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	for _, fltrs := range []storage.ListUpgradesFilter{
@@ -59,7 +59,7 @@ func (s *StorageTestSuite) TestUpgradeList() {
 }
 
 func (s *StorageTestSuite) TestUpgradeByVersion() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	upgrade, err := s.storage.Upgrade.ByVersion(ctx, 1499)

--- a/internal/storage/postgres/validator_test.go
+++ b/internal/storage/postgres/validator_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestValidatorByAddress() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	validator, err := s.storage.Validator.ByAddress(ctx, "celestiavaloper17vmk8m246t648hpmde2q7kp4ft9uwrayy09dmw")
@@ -29,7 +29,7 @@ func (s *StorageTestSuite) TestValidatorByAddress() {
 }
 
 func (s *StorageTestSuite) TestTotalPower() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	power, err := s.storage.Validator.TotalVotingPower(ctx, 100)
@@ -38,7 +38,7 @@ func (s *StorageTestSuite) TestTotalPower() {
 }
 
 func (s *StorageTestSuite) TestListByPower() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	validators, err := s.storage.Validator.ListByPower(ctx, storage.ValidatorFilters{
@@ -49,7 +49,7 @@ func (s *StorageTestSuite) TestListByPower() {
 }
 
 func (s *StorageTestSuite) TestListByPowerWithVersion() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	validators, err := s.storage.Validator.ListByPower(ctx, storage.ValidatorFilters{
@@ -63,7 +63,7 @@ func (s *StorageTestSuite) TestListByPowerWithVersion() {
 }
 
 func (s *StorageTestSuite) TestJailedCount() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	count, err := s.storage.Validator.JailedCount(ctx)
@@ -72,7 +72,7 @@ func (s *StorageTestSuite) TestJailedCount() {
 }
 
 func (s *StorageTestSuite) TestMessages() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	msgs, err := s.storage.Validator.Messages(ctx, 1, storage.ValidatorMessagesFilters{})
@@ -82,7 +82,7 @@ func (s *StorageTestSuite) TestMessages() {
 }
 
 func (s *StorageTestSuite) TestMetrics() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.Connection().Exec(ctx, "REFRESH MATERIALIZED VIEW validator_metrics;")
@@ -99,7 +99,7 @@ func (s *StorageTestSuite) TestMetrics() {
 }
 
 func (s *StorageTestSuite) TestTopNMetrics() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.Connection().Exec(ctx, "REFRESH MATERIALIZED VIEW validator_metrics;")

--- a/internal/storage/postgres/vesting_account_test.go
+++ b/internal/storage/postgres/vesting_account_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *StorageTestSuite) TestVestingAccountByAddress() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	vestings, err := s.storage.VestingAccounts.ByAddress(ctx, 1, 1, 0, true)

--- a/internal/storage/postgres/zkism_test.go
+++ b/internal/storage/postgres/zkism_test.go
@@ -17,7 +17,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func (s *StorageTestSuite) TestZkISMList() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.ZkISM.List(ctx, storage.ZkISMFilter{
@@ -47,7 +47,7 @@ func (s *StorageTestSuite) TestZkISMList() {
 }
 
 func (s *StorageTestSuite) TestZkISMListByCreator() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	creatorId := uint64(1)
@@ -67,7 +67,7 @@ func (s *StorageTestSuite) TestZkISMListByCreator() {
 }
 
 func (s *StorageTestSuite) TestZkISMListByTx() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	txId := uint64(2)
@@ -89,7 +89,7 @@ func (s *StorageTestSuite) TestZkISMListByTx() {
 }
 
 func (s *StorageTestSuite) TestZkISMListOffset() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.ZkISM.List(ctx, storage.ZkISMFilter{
@@ -104,7 +104,7 @@ func (s *StorageTestSuite) TestZkISMListOffset() {
 }
 
 func (s *StorageTestSuite) TestZkISMListAsc() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.ZkISM.List(ctx, storage.ZkISMFilter{
@@ -124,7 +124,7 @@ func (s *StorageTestSuite) TestZkISMListAsc() {
 // ---------------------------------------------------------------------------
 
 func (s *StorageTestSuite) TestZkISMById() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	ism, err := s.storage.ZkISM.ById(ctx, 1)
@@ -149,7 +149,7 @@ func (s *StorageTestSuite) TestZkISMById() {
 }
 
 func (s *StorageTestSuite) TestZkISMByIdNotFound() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	_, err := s.storage.ZkISM.ById(ctx, 999)
@@ -161,7 +161,7 @@ func (s *StorageTestSuite) TestZkISMByIdNotFound() {
 // ---------------------------------------------------------------------------
 
 func (s *StorageTestSuite) TestZkISMUpdates() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.ZkISM.Updates(ctx, 1, storage.ZkISMUpdatesFilter{
@@ -187,7 +187,7 @@ func (s *StorageTestSuite) TestZkISMUpdates() {
 }
 
 func (s *StorageTestSuite) TestZkISMUpdatesBySigner() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	signerId := uint64(1)
@@ -207,7 +207,7 @@ func (s *StorageTestSuite) TestZkISMUpdatesBySigner() {
 }
 
 func (s *StorageTestSuite) TestZkISMUpdatesByTx() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	txId := uint64(2)
@@ -228,7 +228,7 @@ func (s *StorageTestSuite) TestZkISMUpdatesByTx() {
 }
 
 func (s *StorageTestSuite) TestZkISMUpdatesFrom() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	// Row 1 is at 04:11:57, Row 2 is at 05:12:57.
@@ -244,7 +244,7 @@ func (s *StorageTestSuite) TestZkISMUpdatesFrom() {
 }
 
 func (s *StorageTestSuite) TestZkISMUpdatesTo() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	// To 05:00:00 should include only Row 1 (04:11:57 < 05:00:00).
@@ -259,7 +259,7 @@ func (s *StorageTestSuite) TestZkISMUpdatesTo() {
 }
 
 func (s *StorageTestSuite) TestZkISMUpdatesUnknownISM() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.ZkISM.Updates(ctx, 999, storage.ZkISMUpdatesFilter{
@@ -274,7 +274,7 @@ func (s *StorageTestSuite) TestZkISMUpdatesUnknownISM() {
 // ---------------------------------------------------------------------------
 
 func (s *StorageTestSuite) TestZkISMMessages() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.ZkISM.Messages(ctx, 1, storage.ZkISMUpdatesFilter{
@@ -301,7 +301,7 @@ func (s *StorageTestSuite) TestZkISMMessages() {
 }
 
 func (s *StorageTestSuite) TestZkISMMessagesBySigner() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	signerId := uint64(1)
@@ -321,7 +321,7 @@ func (s *StorageTestSuite) TestZkISMMessagesBySigner() {
 }
 
 func (s *StorageTestSuite) TestZkISMMessagesByTx() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	txId := uint64(1)
@@ -342,7 +342,7 @@ func (s *StorageTestSuite) TestZkISMMessagesByTx() {
 }
 
 func (s *StorageTestSuite) TestZkISMMessagesFrom() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	from := time.Date(2023, 7, 4, 5, 0, 0, 0, time.UTC)
@@ -356,7 +356,7 @@ func (s *StorageTestSuite) TestZkISMMessagesFrom() {
 }
 
 func (s *StorageTestSuite) TestZkISMMessagesUnknownISM() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, ctxCancel := context.WithTimeout(s.T().Context(), 5*time.Second)
 	defer ctxCancel()
 
 	items, err := s.storage.ZkISM.Messages(ctx, 999, storage.ZkISMUpdatesFilter{

--- a/pkg/indexer/parser/parser_prod_test.go
+++ b/pkg/indexer/parser/parser_prod_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func testFromFile(t *testing.T, filename string) {
+	t.Helper()
+
 	blockFile, err := os.Open(fmt.Sprintf("../../../test/json/block_%s.json", filename))
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/indexer/parser/parser_test.go
+++ b/pkg/indexer/parser/parser_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func createModules(t *testing.T) (modules.BaseModule, string, Module) {
+	t.Helper()
+
 	writerModule := modules.New("writer-module")
 	outputName := "write"
 	writerModule.CreateOutput(outputName)

--- a/pkg/indexer/rollback/rollback_test.go
+++ b/pkg/indexer/rollback/rollback_test.go
@@ -50,6 +50,11 @@ func (s *ModuleTestSuite) SetupSuite() {
 	})
 	s.Require().NoError(err)
 	s.psqlContainer = psqlContainer
+	s.T().Cleanup(func() {
+		ctx, ctxCancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer ctxCancel()
+		s.Require().NoError(s.psqlContainer.Terminate(ctx))
+	})
 
 	st, err := postgres.Create(ctx, config.Database{
 		Kind:     config.DBKindPostgres,
@@ -61,15 +66,9 @@ func (s *ModuleTestSuite) SetupSuite() {
 	}, "../../../database", false)
 	s.Require().NoError(err)
 	s.storage = st
-}
-
-// TearDownSuite -
-func (s *ModuleTestSuite) TearDownSuite() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer ctxCancel()
-
-	s.Require().NoError(s.storage.Close())
-	s.Require().NoError(s.psqlContainer.Terminate(ctx))
+	s.T().Cleanup(func() {
+		s.Require().NoError(s.storage.Close())
+	})
 }
 
 func (s *ModuleTestSuite) InitDb(path string) {

--- a/pkg/indexer/storage/storage_test.go
+++ b/pkg/indexer/storage/storage_test.go
@@ -43,6 +43,11 @@ func (s *ModuleTestSuite) SetupSuite() {
 	})
 	s.Require().NoError(err)
 	s.psqlContainer = psqlContainer
+	s.T().Cleanup(func() {
+		ctx, ctxCancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer ctxCancel()
+		s.Require().NoError(s.psqlContainer.Terminate(ctx))
+	})
 
 	strg, err := postgres.Create(ctx, config.Database{
 		Kind:     config.DBKindPostgres,
@@ -54,6 +59,9 @@ func (s *ModuleTestSuite) SetupSuite() {
 	}, "../../../database", false)
 	s.Require().NoError(err)
 	s.storage = strg
+	s.T().Cleanup(func() {
+		s.Require().NoError(s.storage.Close())
+	})
 
 	fixtures, err := testfixtures.New(
 		testfixtures.Database(strg.Connection().DB().DB),
@@ -63,15 +71,6 @@ func (s *ModuleTestSuite) SetupSuite() {
 	)
 	s.Require().NoError(err)
 	s.Require().NoError(fixtures.Load())
-}
-
-// TearDownSuite -
-func (s *ModuleTestSuite) TearDownSuite() {
-	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer ctxCancel()
-
-	s.Require().NoError(s.storage.Close())
-	s.Require().NoError(s.psqlContainer.Terminate(ctx))
 }
 
 func (s *ModuleTestSuite) TestBlockLast() {


### PR DESCRIPTION
## Summary

Cleans up the DB-backed test suites across the repo: consistent use of `t.Context()`/`s.T().Context()` for test-scoped contexts, `t.Cleanup()` for teardown of shared resources (Postgres testcontainers, storage connections), and `t.Helper()` on shared test helper functions — replacing the previous `context.Background()` + manual `TearDownSuite` pattern.

## Changes

- **Context propagation**: replaced `context.Background()` with `s.T().Context()` (suite tests) / `t.Context()` (plain tests) throughout `internal/storage/postgres/*_test.go` and `cmd/api/handler/*_test.go`, so per-test contexts are cancelled automatically when a test ends instead of living for the process lifetime.
- **Resource cleanup via `t.Cleanup()`**: in the suites that spin up a `testhelpers.PostgreSQLContainer` + `Storage` (`internal/storage/postgres/{storage,block_stats,transaction,stats,core}_test.go`, `pkg/indexer/storage/storage_test.go`, `pkg/indexer/rollback/rollback_test.go`), teardown is now registered with `s.T().Cleanup(...)` / `t.Cleanup(...)` right next to where each resource is created, instead of a separate `TearDownSuite` method. This ties cleanup directly to acquisition and makes it resilient to a later step in `SetupSuite` failing (the container/connection still gets torn down instead of leaking). Cleanup closures use `context.Background()` rather than the test's own context, since `t.Context()` is already cancelled by the time `Cleanup` callbacks run.
- **Removed redundant `ctrl.Finish()`**: dropped manual `s.ctrl.Finish()` calls in ~12 `cmd/api/handler/*_test.go` suites — `gomock.NewController(s.T())` (go.uber.org/mock v0.6.0) already registers its own `t.Cleanup(ctrl.Finish)`, so the manual call was a no-op duplicate.
- **Added `t.Helper()`**: to the shared test helpers `testFromFile` (`pkg/indexer/parser/parser_prod_test.go`) and `createModules` (`pkg/indexer/parser/parser_test.go`), matching the existing pattern used elsewhere (`manager_test.go`, `jx_decoder_test.go`, `blobtx_test.go`, `tx_hash_test.go`), so failures report the calling test's line instead of the helper's.

## Why

No functional/behavioral change to the code under test — this is purely a test-hygiene pass to make setup/teardown more robust (no leaked Docker containers on partial `SetupSuite` failure) and to align every suite with the same convention.