### PR TITLE
Fix: use initial_height from genesis

### DIFF
--- a/pkg/indexer/genesis/genesis_test.go
+++ b/pkg/indexer/genesis/genesis_test.go
@@ -168,3 +168,36 @@ func TestParseBalances_ExistingAddressNewCurrency(t *testing.T) {
 	require.Equal(t, storageTypes.NumericFromInt64(100), byCurrency["utia"])
 	require.Equal(t, storageTypes.NumericFromInt64(50), byCurrency["ibc/AAA"])
 }
+
+func loadGenesisFixture(t *testing.T) types.Genesis {
+	f, err := os.Open("../../../test/json/genesis.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	var g types.Genesis
+	err = json.ConfigFastest.NewDecoder(f).Decode(&g)
+	require.NoError(t, err)
+	return g
+}
+
+// Exported genesis has validators/delegations in app_state.staking.*, not gen_txs — must fail, not index an empty set.
+func TestParse_ExportedGenesisFailsFast(t *testing.T) {
+	g := loadGenesisFixture(t)
+	g.AppState.Staking.Exported = true
+
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+	_, err := module.parse(types.GenesisOutput{Genesis: g})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exported")
+}
+
+// gen_txs cleared: the fixture's gen_tx has an empty fee amount, which DecodeFee rejects unrelatedly.
+func TestParse_NonExportedGenesisSucceeds(t *testing.T) {
+	g := loadGenesisFixture(t)
+	require.False(t, g.AppState.Staking.Exported, "fixture is expected to represent a fresh, non-exported genesis")
+	g.AppState.Genutil.GenTxs = nil
+
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+	_, err := module.parse(types.GenesisOutput{Genesis: g})
+	require.NoError(t, err)
+}

--- a/pkg/indexer/genesis/parse.go
+++ b/pkg/indexer/genesis/parse.go
@@ -48,6 +48,10 @@ func newParsedData() parsedData {
 }
 
 func (module *Module) parse(genesis types.GenesisOutput) (parsedData, error) {
+	if genesis.AppState.Staking.Exported {
+		return parsedData{}, errors.New("genesis was produced by state export (app_state.staking.exported=true): validators and delegations are not read from gen_txs in this case and parsing them is not supported")
+	}
+
 	data := newParsedData()
 	block := storage.Block{
 		Time:    genesis.GenesisTime,

--- a/pkg/indexer/receiver/genesis.go
+++ b/pkg/indexer/receiver/genesis.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/celenium-io/celestia-indexer/pkg/node/types"
+	pkgTypes "github.com/celenium-io/celestia-indexer/pkg/types"
 	"github.com/pkg/errors"
 )
 
@@ -23,6 +24,10 @@ func (r *Module) receiveGenesis(ctx context.Context) error {
 	}
 
 	r.Log.Info().Msgf("got initial height of genesis block: %d", genesis.InitialHeight)
+	startLevel := pkgTypes.Level(max(genesis.InitialHeight-1, r.cfg.StartLevel))
+	r.level = startLevel
+	r.receivedLevel = startLevel
+
 	r.MustOutput(GenesisOutput).Push(types.GenesisOutput{
 		Genesis:    genesis,
 		ModuleAccs: moduleAccounts,

--- a/pkg/indexer/receiver/genesis_test.go
+++ b/pkg/indexer/receiver/genesis_test.go
@@ -46,11 +46,7 @@ func (s *ModuleTestSuite) runReceiveGenesis(cfg *ic.Indexer, initialHeight int64
 	return receiverModule
 }
 
-// TestReceiveGenesis_DefaultStartLevel verifies that with the default (unset)
-// start_level and the network's usual initial_height=1, the receiver still
-// begins fetching from block 1 (level=0, receivedLevel=0), exactly as before
-// genesis.InitialHeight was taken into account. A regression here would
-// silently skip the chain's first block.
+// Default start_level + initial_height=1 must still start at block 1 (level=receivedLevel=0).
 func (s *ModuleTestSuite) TestReceiveGenesis_DefaultStartLevel() {
 	receiverModule := s.runReceiveGenesis(&ic.Indexer{Name: testIndexerName}, 1)
 
@@ -60,10 +56,7 @@ func (s *ModuleTestSuite) TestReceiveGenesis_DefaultStartLevel() {
 		"level and receivedLevel must stay in sync or the sequencer will skip the first block")
 }
 
-// TestReceiveGenesis_InitialHeightAboveOne verifies that when a chain's
-// genesis declares initial_height > 1 (e.g. a re-genesis that continues
-// height numbering), the receiver starts fetching from initial_height
-// instead of from block 1, which doesn't exist on such a chain.
+// initial_height > 1 (re-genesis) must start fetching from initial_height, not block 1.
 func (s *ModuleTestSuite) TestReceiveGenesis_InitialHeightAboveOne() {
 	receiverModule := s.runReceiveGenesis(&ic.Indexer{Name: testIndexerName}, 1000)
 
@@ -71,9 +64,7 @@ func (s *ModuleTestSuite) TestReceiveGenesis_InitialHeightAboveOne() {
 	s.Require().EqualValues(999, receiverModule.receivedLevel)
 }
 
-// TestReceiveGenesis_ExplicitStartLevelOverride verifies that an operator's
-// explicit start_level (used to skip ahead in a re-sync) is preserved when
-// it is already past the chain's initial_height.
+// An explicit start_level past initial_height (skip-ahead re-sync) must be preserved.
 func (s *ModuleTestSuite) TestReceiveGenesis_ExplicitStartLevelOverride() {
 	receiverModule := s.runReceiveGenesis(&ic.Indexer{Name: testIndexerName, StartLevel: 500_000}, 1)
 
@@ -81,9 +72,7 @@ func (s *ModuleTestSuite) TestReceiveGenesis_ExplicitStartLevelOverride() {
 	s.Require().EqualValues(500_000, receiverModule.receivedLevel)
 }
 
-// TestReceiveGenesis_StartLevelBelowInitialHeight verifies that a start_level
-// lower than the chain's initial_height-1 is clamped up, since blocks below
-// initial_height don't exist on the node.
+// A start_level below initial_height-1 must be clamped up: blocks below initial_height don't exist.
 func (s *ModuleTestSuite) TestReceiveGenesis_StartLevelBelowInitialHeight() {
 	receiverModule := s.runReceiveGenesis(&ic.Indexer{Name: testIndexerName, StartLevel: 500}, 1000)
 

--- a/pkg/indexer/receiver/genesis_test.go
+++ b/pkg/indexer/receiver/genesis_test.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2025 Bb Strategy Pte. Ltd. <celenium@baking-bad.org>
+// SPDX-License-Identifier: MIT
+
+package receiver
+
+import (
+	"context"
+	"time"
+
+	ic "github.com/celenium-io/celestia-indexer/pkg/indexer/config"
+	nodeTypes "github.com/celenium-io/celestia-indexer/pkg/node/types"
+	"go.uber.org/mock/gomock"
+)
+
+func (s *ModuleTestSuite) runReceiveGenesis(cfg *ic.Indexer, initialHeight int64) *Module {
+	s.InitApi(func() {
+		s.api.EXPECT().
+			Genesis(gomock.Any()).
+			Return(nodeTypes.Genesis{InitialHeight: initialHeight}, nil).
+			Times(1)
+		s.cosmosApi.EXPECT().
+			ModuleAccounts(gomock.Any()).
+			Return(nil, nil).
+			Times(1)
+	})
+
+	receiverModule := s.createModuleEmptyState(cfg)
+
+	ctx, cancel := context.WithTimeout(s.T().Context(), 5*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- receiverModule.receiveGenesis(ctx)
+	}()
+
+	receiverModule.MustInput(GenesisDoneInput).Push(struct{}{})
+
+	select {
+	case err := <-done:
+		s.Require().NoError(err)
+	case <-time.After(5 * time.Second):
+		s.FailNow("receiveGenesis did not return in time")
+	}
+
+	return receiverModule
+}
+
+// TestReceiveGenesis_DefaultStartLevel verifies that with the default (unset)
+// start_level and the network's usual initial_height=1, the receiver still
+// begins fetching from block 1 (level=0, receivedLevel=0), exactly as before
+// genesis.InitialHeight was taken into account. A regression here would
+// silently skip the chain's first block.
+func (s *ModuleTestSuite) TestReceiveGenesis_DefaultStartLevel() {
+	receiverModule := s.runReceiveGenesis(&ic.Indexer{Name: testIndexerName}, 1)
+
+	s.Require().EqualValues(0, receiverModule.level)
+	s.Require().EqualValues(0, receiverModule.receivedLevel)
+	s.Require().Equal(receiverModule.level, receiverModule.receivedLevel,
+		"level and receivedLevel must stay in sync or the sequencer will skip the first block")
+}
+
+// TestReceiveGenesis_InitialHeightAboveOne verifies that when a chain's
+// genesis declares initial_height > 1 (e.g. a re-genesis that continues
+// height numbering), the receiver starts fetching from initial_height
+// instead of from block 1, which doesn't exist on such a chain.
+func (s *ModuleTestSuite) TestReceiveGenesis_InitialHeightAboveOne() {
+	receiverModule := s.runReceiveGenesis(&ic.Indexer{Name: testIndexerName}, 1000)
+
+	s.Require().EqualValues(999, receiverModule.level)
+	s.Require().EqualValues(999, receiverModule.receivedLevel)
+}
+
+// TestReceiveGenesis_ExplicitStartLevelOverride verifies that an operator's
+// explicit start_level (used to skip ahead in a re-sync) is preserved when
+// it is already past the chain's initial_height.
+func (s *ModuleTestSuite) TestReceiveGenesis_ExplicitStartLevelOverride() {
+	receiverModule := s.runReceiveGenesis(&ic.Indexer{Name: testIndexerName, StartLevel: 500_000}, 1)
+
+	s.Require().EqualValues(500_000, receiverModule.level)
+	s.Require().EqualValues(500_000, receiverModule.receivedLevel)
+}
+
+// TestReceiveGenesis_StartLevelBelowInitialHeight verifies that a start_level
+// lower than the chain's initial_height-1 is clamped up, since blocks below
+// initial_height don't exist on the node.
+func (s *ModuleTestSuite) TestReceiveGenesis_StartLevelBelowInitialHeight() {
+	receiverModule := s.runReceiveGenesis(&ic.Indexer{Name: testIndexerName, StartLevel: 500}, 1000)
+
+	s.Require().EqualValues(999, receiverModule.level)
+	s.Require().EqualValues(999, receiverModule.receivedLevel)
+}


### PR DESCRIPTION
### Summary

The receiver's starting sync level was derived only from `INDEXER_START_LEVEL` (config), independent of the chain's actual `genesis.initial_height`. This works by coincidence for networks where `initial_height` is `1` (the block-fetch loop starts at `receivedLevel + 1 = 1`), but breaks for any chain whose genesis declares a higher `initial_height` (e.g. a re-genesis that continues height numbering from a previous chain) — the indexer would try to fetch blocks below `initial_height`, which don't exist on the node.

- Set `r.level` / `r.receivedLevel` from `max(genesis.InitialHeight - 1, cfg.StartLevel)` right after the genesis block is fetched, instead of relying solely on `cfg.StartLevel`.
- Preserves an operator-provided `start_level` when it's already past the chain's genesis (e.g. skipping ahead on a re-sync); clamps it up when it would point below the chain's actual first block.
- `level` and `receivedLevel` are kept equal, matching the invariant `NewModule` already relies on — the sequencer expects the next delivered block to be `level + 1`, matching what `sync` fetches from `receivedLevel + 1`. Setting them to different values (as an earlier draft of this fix did) causes the sequencer to permanently wait for a block one higher than what's ever fetched, silently dropping the chain's first block.

### Tests

Added `pkg/indexer/receiver/genesis_test.go`, driving `receiveGenesis` directly with mocked `Genesis`/`ModuleAccounts` calls:
- default config + `initial_height=1` → starts at block 1 (regression guard for existing networks)
- `initial_height=1000`, no override → starts at block 1000
- explicit `start_level` past genesis → override preserved
- explicit `start_level` below `initial_height` → clamped up to genesis