### PR TITLE
Feat: parsing authz in genesis block + refactoring genesis block parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,7 @@ stopperModule.AttachTo(r, receiver.StopOutput, stopper.InputName)
 - Active linters to watch: `zerologlint`, `musttag`, `gosec`, `containedctx`
 - SPDX license headers required on all new files: `// SPDX-FileCopyrightText: 2025 Bb Strategy Pte. Ltd. <celenium@baking-bad.org>` + `// SPDX-License-Identifier: MIT` (run `make license-header` to apply automatically)
 - JSON marshaling uses `github.com/bytedance/sonic` (faster than `encoding/json`)
+- Keep comments short — 1-2 lines max. No multi-paragraph doc comments; explain the non-obvious "why" tersely, not the "what"
 
 ## Entity Types Overview
 

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.uber.org/mock v0.6.0
-	golang.org/x/exp v0.0.0-20260112195511-716be5621a96
+	golang.org/x/exp v0.0.0-20260820142414-ca536658362e // indirect
 	golang.org/x/time v0.15.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1144,8 +1144,8 @@ golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2d
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
-golang.org/x/exp v0.0.0-20260112195511-716be5621a96 h1:Z/6YuSHTLOHfNFdb8zVZomZr7cqNgTJvA8+Qz75D8gU=
-golang.org/x/exp v0.0.0-20260112195511-716be5621a96/go.mod h1:nzimsREAkjBCIEFtHiYkrJyT+2uy9YZJB7H1k68CXZU=
+golang.org/x/exp v0.0.0-20260820142414-ca536658362e h1:01Ju2A/fZKkci4zqx0eZxw//DnRYOnBiGJG14hFBhO8=
+golang.org/x/exp v0.0.0-20260820142414-ca536658362e/go.mod h1:zeBbvyFKDaLwa7CH/zI8KXt7gTl14SF7sO08Pl5jBCM=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -1300,8 +1300,8 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.8/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
-golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
-golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
+golang.org/x/tools v0.49.0 h1:3NI7VXzL9+1WZD52Dx2ttoPwD5DWrFGpl9mFZDlmisI=
+golang.org/x/tools v0.49.0/go.mod h1:SJNXV9DBKT0UbdttsQjbfJlAE/q+y36++zo3uL3N0Oo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/storage/postgres/migrations/20260824000001_add_module_minfee.go
+++ b/internal/storage/postgres/migrations/20260824000001_add_module_minfee.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2025 Bb Strategy Pte. Ltd. <celenium@baking-bad.org>
+// SPDX-License-Identifier: MIT
+
+package migrations
+
+import (
+	"context"
+
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	Migrations.MustRegister(upAddModuleMinfee, downAddModuleMinfee)
+}
+
+func upAddModuleMinfee(ctx context.Context, db *bun.DB) error {
+	_, err := db.ExecContext(ctx, `
+		ALTER TYPE module_name ADD VALUE IF NOT EXISTS 'minfee'
+	`)
+	return err
+}
+
+func downAddModuleMinfee(ctx context.Context, db *bun.DB) error {
+	_, err := db.ExecContext(ctx, `
+		DELETE FROM pg_enum 
+		WHERE enumlabel = 'minfee' AND enumtypid = (
+			SELECT oid FROM pg_type WHERE typname = 'module_name'
+		)
+	`)
+	return err
+}

--- a/internal/storage/types/module.go
+++ b/internal/storage/types/module.go
@@ -16,7 +16,8 @@ package types
 		staking,
 		consensus,
 		baseapp,
-		icahost
+		icahost,
+		minfee
 	)
 */
 //go:generate go-enum --marshal --sql --values

--- a/internal/storage/types/module_enum.go
+++ b/internal/storage/types/module_enum.go
@@ -38,6 +38,8 @@ const (
 	ModuleNameBaseapp ModuleName = "baseapp"
 	// ModuleNameIcahost is a ModuleName of type icahost.
 	ModuleNameIcahost ModuleName = "icahost"
+	// ModuleNameMinfee is a ModuleName of type minfee.
+	ModuleNameMinfee ModuleName = "minfee"
 )
 
 var ErrInvalidModuleName = errors.New("not a valid ModuleName")
@@ -56,6 +58,7 @@ func ModuleNameValues() []ModuleName {
 		ModuleNameConsensus,
 		ModuleNameBaseapp,
 		ModuleNameIcahost,
+		ModuleNameMinfee,
 	}
 }
 
@@ -83,6 +86,7 @@ var _ModuleNameValue = map[string]ModuleName{
 	"consensus":    ModuleNameConsensus,
 	"baseapp":      ModuleNameBaseapp,
 	"icahost":      ModuleNameIcahost,
+	"minfee":       ModuleNameMinfee,
 }
 
 // ParseModuleName attempts to convert a string to a ModuleName.

--- a/pkg/indexer/decode/context/context.go
+++ b/pkg/indexer/decode/context/context.go
@@ -53,6 +53,7 @@ type Context struct {
 	IbcTransfers    []*storage.IbcTransfer
 	BlobLogs        []*storage.BlobLog
 	Signals         []*storage.SignalVersion
+	DenomMetadata   []storage.DenomMetadata
 
 	Block         *storage.Block
 	TryUpgrade    *storage.Upgrade
@@ -97,6 +98,7 @@ func NewContext() *Context {
 		HlTransfers:     make([]*storage.HLTransfer, 0),
 		IbcTransfers:    make([]*storage.IbcTransfer, 0),
 		Signals:         make([]*storage.SignalVersion, 0),
+		DenomMetadata:   make([]storage.DenomMetadata, 0),
 
 		msgCounter: new(atomic.Int64),
 	}
@@ -497,4 +499,8 @@ func (ctx *Context) AddBlobLogs(logs ...*storage.BlobLog) {
 
 func (ctx *Context) AddAddressMessage(msg *storage.MsgAddress) {
 	ctx.AddressMessages.Set(msg.String(), msg)
+}
+
+func (ctx *Context) AddDenomMetadata(metadata ...storage.DenomMetadata) {
+	ctx.DenomMetadata = append(ctx.DenomMetadata, metadata...)
 }

--- a/pkg/indexer/decode/handle/authz.go
+++ b/pkg/indexer/decode/handle/authz.go
@@ -114,19 +114,7 @@ func parseGrants(msg *authz.MsgGrant, t time.Time, height pkgTypes.Level) ([]*st
 			return nil, err
 		}
 		return []*storage.Grant{
-			{
-				Params:        structs.Map(typ),
-				Authorization: typ.MsgTypeURL(),
-				Granter: &storage.Address{
-					Address: msg.Granter,
-				},
-				Grantee: &storage.Address{
-					Address: msg.Grantee,
-				},
-				Height:     height,
-				Expiration: msg.Grant.Expiration,
-				Time:       t,
-			},
+			makeGrant(msg, "", t, height, structs.Map(typ)),
 		}, nil
 	case "/cosmos.bank.v1beta1.SendAuthorization":
 		var typ bankTypes.SendAuthorization
@@ -134,19 +122,7 @@ func parseGrants(msg *authz.MsgGrant, t time.Time, height pkgTypes.Level) ([]*st
 			return nil, err
 		}
 		return []*storage.Grant{
-			{
-				Params:        structs.Map(typ),
-				Authorization: "/cosmos.bank.v1beta1.MsgSend",
-				Granter: &storage.Address{
-					Address: msg.Granter,
-				},
-				Grantee: &storage.Address{
-					Address: msg.Grantee,
-				},
-				Height:     height,
-				Expiration: msg.Grant.Expiration,
-				Time:       t,
-			},
+			makeGrant(msg, "/cosmos.bank.v1beta1.MsgSend", t, height, structs.Map(typ)),
 		}, nil
 	case "/cosmos.staking.v1beta1.StakeAuthorization":
 		var typ stakingTypes.StakeAuthorization
@@ -156,93 +132,54 @@ func parseGrants(msg *authz.MsgGrant, t time.Time, height pkgTypes.Level) ([]*st
 		switch typ.AuthorizationType {
 		case stakingTypes.AuthorizationType_AUTHORIZATION_TYPE_DELEGATE:
 			return []*storage.Grant{
-				{
-					Params:        structs.Map(typ),
-					Authorization: "/cosmos.staking.v1beta1.MsgDelegate",
-					Granter: &storage.Address{
-						Address: msg.Granter,
-					},
-					Grantee: &storage.Address{
-						Address: msg.Grantee,
-					},
-					Height:     height,
-					Expiration: msg.Grant.Expiration,
-					Time:       t,
-				},
+				makeGrant(msg, "/cosmos.staking.v1beta1.MsgDelegate", t, height, structs.Map(typ)),
 			}, nil
 		case stakingTypes.AuthorizationType_AUTHORIZATION_TYPE_REDELEGATE:
 			return []*storage.Grant{
-				{
-					Params:        structs.Map(typ),
-					Authorization: "/cosmos.staking.v1beta1.MsgRedelegate",
-					Granter: &storage.Address{
-						Address: msg.Granter,
-					},
-					Grantee: &storage.Address{
-						Address: msg.Grantee,
-					},
-					Height:     height,
-					Expiration: msg.Grant.Expiration,
-					Time:       t,
-				},
+				makeGrant(msg, "/cosmos.staking.v1beta1.MsgRedelegate", t, height, structs.Map(typ)),
 			}, nil
 		case stakingTypes.AuthorizationType_AUTHORIZATION_TYPE_UNDELEGATE:
 			return []*storage.Grant{
-				{
-					Params:        structs.Map(typ),
-					Authorization: "/cosmos.staking.v1beta1.MsgUndelegate",
-					Granter: &storage.Address{
-						Address: msg.Granter,
-					},
-					Grantee: &storage.Address{
-						Address: msg.Grantee,
-					},
-					Height:     height,
-					Expiration: msg.Grant.Expiration,
-					Time:       t,
-				},
+				makeGrant(msg, "/cosmos.staking.v1beta1.MsgUndelegate", t, height, structs.Map(typ)),
+			}, nil
+		case stakingTypes.AuthorizationType_AUTHORIZATION_TYPE_CANCEL_UNBONDING_DELEGATION:
+			return []*storage.Grant{
+				makeGrant(msg, "/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation", t, height, structs.Map(typ)),
 			}, nil
 		case stakingTypes.AuthorizationType_AUTHORIZATION_TYPE_UNSPECIFIED:
 			return []*storage.Grant{
-				{
-					Params:        structs.Map(typ),
-					Authorization: "/cosmos.staking.v1beta1.MsgDelegate",
-					Granter: &storage.Address{
-						Address: msg.Granter,
-					},
-					Grantee: &storage.Address{
-						Address: msg.Grantee,
-					},
-					Height:     height,
-					Expiration: msg.Grant.Expiration,
-					Time:       t,
-				}, {
-					Params:        structs.Map(typ),
-					Authorization: "/cosmos.staking.v1beta1.MsgRedelegate",
-					Granter: &storage.Address{
-						Address: msg.Granter,
-					},
-					Grantee: &storage.Address{
-						Address: msg.Grantee,
-					},
-					Height:     height,
-					Expiration: msg.Grant.Expiration,
-					Time:       t,
-				}, {
-					Params:        structs.Map(typ),
-					Authorization: "/cosmos.staking.v1beta1.MsgUndelegate",
-					Granter: &storage.Address{
-						Address: msg.Granter,
-					},
-					Grantee: &storage.Address{
-						Address: msg.Grantee,
-					},
-					Height:     height,
-					Expiration: msg.Grant.Expiration,
-					Time:       t,
-				},
+				makeGrant(msg, "/cosmos.staking.v1beta1.MsgDelegate", t, height, structs.Map(typ)),
+				makeGrant(msg, "/cosmos.staking.v1beta1.MsgRedelegate", t, height, structs.Map(typ)),
+				makeGrant(msg, "/cosmos.staking.v1beta1.MsgUndelegate", t, height, structs.Map(typ)),
+				makeGrant(msg, "/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation", t, height, structs.Map(typ)),
+			}, nil
+		default:
+			return []*storage.Grant{
+				makeGrant(msg, "", t, height, structs.Map(typ)),
 			}, nil
 		}
+	default:
+		return []*storage.Grant{
+			makeGrant(msg, "", t, height, nil),
+		}, nil
 	}
-	return nil, nil
+}
+
+func makeGrant(msg *authz.MsgGrant, typ string, t time.Time, height pkgTypes.Level, params map[string]any) *storage.Grant {
+	if typ == "" {
+		typ = msg.Grant.Authorization.TypeUrl
+	}
+	return &storage.Grant{
+		Params:        params,
+		Authorization: typ,
+		Granter: &storage.Address{
+			Address: msg.Granter,
+		},
+		Grantee: &storage.Address{
+			Address: msg.Grantee,
+		},
+		Height:     height,
+		Expiration: msg.Grant.Expiration,
+		Time:       t,
+	}
 }

--- a/pkg/indexer/decode/handle/authz.go
+++ b/pkg/indexer/decode/handle/authz.go
@@ -114,7 +114,7 @@ func parseGrants(msg *authz.MsgGrant, t time.Time, height pkgTypes.Level) ([]*st
 			return nil, err
 		}
 		return []*storage.Grant{
-			makeGrant(msg, "", t, height, structs.Map(typ)),
+			makeGrant(msg, typ.MsgTypeURL(), t, height, structs.Map(typ)),
 		}, nil
 	case "/cosmos.bank.v1beta1.SendAuthorization":
 		var typ bankTypes.SendAuthorization

--- a/pkg/indexer/decode/handle/authz.go
+++ b/pkg/indexer/decode/handle/authz.go
@@ -165,9 +165,11 @@ func parseGrants(msg *authz.MsgGrant, t time.Time, height pkgTypes.Level) ([]*st
 	}
 }
 
+const unknownTypeURL = "unknown_type_url"
+
 func makeGrant(msg *authz.MsgGrant, typ string, t time.Time, height pkgTypes.Level, params map[string]any) *storage.Grant {
 	if typ == "" {
-		typ = msg.Grant.Authorization.TypeUrl
+		typ = unknownTypeURL
 	}
 	return &storage.Grant{
 		Params:        params,

--- a/pkg/indexer/decode/handle/test/authz_test.go
+++ b/pkg/indexer/decode/handle/test/authz_test.go
@@ -55,7 +55,7 @@ func TestDecodeMsg_SuccessOnMsgGrant(t *testing.T) {
 			Grantee: &storage.Address{
 				Address: "celestia1vnflc6322f8z7cpl28r7un5dxhmjxghc20aydq",
 			},
-			Authorization: "/cosmos.authz.v1beta1.GenericAuthorization",
+			Authorization: "unknown_type_url",
 			Params: map[string]any{
 				"Msg": "",
 			},
@@ -85,7 +85,7 @@ func TestDecodeMsg_SuccessOnMsgGrant(t *testing.T) {
 }
 
 // An authorization type outside the known switch falls back to a generic grant
-// (raw type URL, no decoded Params) instead of being dropped or erroring out.
+// (unknown_type_url, no decoded Params) instead of being dropped or erroring out.
 func TestDecodeMsg_SuccessOnMsgGrant_UnrecognizedAuthorization(t *testing.T) {
 	m := &authz.MsgGrant{
 		Granter: "celestia18r6ujzzkg6ku9sr39nxy4847q4qea5kg4a8pxv",
@@ -109,7 +109,7 @@ func TestDecodeMsg_SuccessOnMsgGrant_UnrecognizedAuthorization(t *testing.T) {
 	require.EqualValues(t, 1, decodeCtx.Grants.Len())
 
 	for _, grant := range decodeCtx.Grants.All() {
-		require.Equal(t, "/ibc.applications.transfer.v1.TransferAuthorization", grant.Authorization)
+		require.Equal(t, "unknown_type_url", grant.Authorization)
 		require.Nil(t, grant.Params)
 		require.Equal(t, m.Granter, grant.Granter.Address)
 		require.Equal(t, m.Grantee, grant.Grantee.Address)

--- a/pkg/indexer/decode/handle/test/authz_test.go
+++ b/pkg/indexer/decode/handle/test/authz_test.go
@@ -55,7 +55,7 @@ func TestDecodeMsg_SuccessOnMsgGrant(t *testing.T) {
 			Grantee: &storage.Address{
 				Address: "celestia1vnflc6322f8z7cpl28r7un5dxhmjxghc20aydq",
 			},
-			Authorization: "",
+			Authorization: "/cosmos.authz.v1beta1.GenericAuthorization",
 			Params: map[string]any{
 				"Msg": "",
 			},
@@ -79,8 +79,41 @@ func TestDecodeMsg_SuccessOnMsgGrant(t *testing.T) {
 	require.Equal(t, msgExpected, dm.Msg)
 	require.EqualValues(t, decodeCtx.Grants.Len(), 1)
 
-	for _, value := range decodeCtx.Grants.All() {
-		require.Equal(t, value, grants[0])
+	for grant := range decodeCtx.Grants.AllValues() {
+		require.Equal(t, grants[0], grant)
+	}
+}
+
+// An authorization type outside the known switch falls back to a generic grant
+// (raw type URL, no decoded Params) instead of being dropped or erroring out.
+func TestDecodeMsg_SuccessOnMsgGrant_UnrecognizedAuthorization(t *testing.T) {
+	m := &authz.MsgGrant{
+		Granter: "celestia18r6ujzzkg6ku9sr39nxy4847q4qea5kg4a8pxv",
+		Grantee: "celestia1vnflc6322f8z7cpl28r7un5dxhmjxghc20aydq",
+		Grant: authz.Grant{
+			Authorization: &codecTypes.Any{
+				TypeUrl: "/ibc.applications.transfer.v1.TransferAuthorization",
+			},
+			Expiration: nil,
+		},
+	}
+	block, _ := testsuite.EmptyBlock()
+	decodeCtx := context.NewContext()
+	decodeCtx.Block = &storage.Block{
+		Height: block.Height,
+		Time:   block.Block.Time,
+	}
+
+	_, err := decode.Message(decodeCtx, m, 4, storageTypes.StatusSuccess, 0)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, decodeCtx.Grants.Len())
+
+	for _, grant := range decodeCtx.Grants.All() {
+		require.Equal(t, "/ibc.applications.transfer.v1.TransferAuthorization", grant.Authorization)
+		require.Nil(t, grant.Params)
+		require.Equal(t, m.Granter, grant.Granter.Address)
+		require.Equal(t, m.Grantee, grant.Grantee.Address)
+		require.Equal(t, block.Height, grant.Height)
 	}
 }
 

--- a/pkg/indexer/decode/tx.go
+++ b/pkg/indexer/decode/tx.go
@@ -105,7 +105,7 @@ func decodeCosmosTx(decoder cosmosTypes.TxDecoder, raw tmTypes.Tx, d *DecodedTx)
 }
 
 func DecodeFee(amount cosmosTypes.Coins) (decimal.Decimal, error) {
-	if amount == nil {
+	if len(amount) == 0 {
 		return decimal.Zero, nil
 	}
 

--- a/pkg/indexer/decode/tx_test.go
+++ b/pkg/indexer/decode/tx_test.go
@@ -258,6 +258,12 @@ func TestDecodeFee(t *testing.T) {
 			expectedErr: "",
 		},
 		{
+			desc:        "Empty but non-nil fee",
+			amount:      types.Coins{},
+			expectedFee: decimal.Zero,
+			expectedErr: "",
+		},
+		{
 			desc: "Valid UTIA fee",
 			amount: types.Coins{
 				types.NewCoin("utia", math.NewInt(1000)),

--- a/pkg/indexer/genesis/constant.go
+++ b/pkg/indexer/genesis/constant.go
@@ -8,113 +8,113 @@ import (
 	"strings"
 	"time"
 
-	"github.com/celenium-io/celestia-indexer/internal/storage"
 	storageTypes "github.com/celenium-io/celestia-indexer/internal/storage/types"
+	decodeContext "github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/celenium-io/celestia-indexer/pkg/node/types"
 	pkgTypes "github.com/celenium-io/celestia-indexer/pkg/types"
 	"github.com/pkg/errors"
 )
 
-func (module *Module) parseConstants(appState types.AppState, consensus pkgTypes.ConsensusParams, data *parsedData) error {
+func (module *Module) parseConstants(ctx *decodeContext.Context, appState types.AppState, consensus pkgTypes.ConsensusParams) error {
 	// consensus
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameConsensus,
-		Name:   "block_max_bytes",
-		Value:  strconv.FormatInt(consensus.Block.MaxBytes, 10),
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameConsensus,
-		Name:   "block_max_gas",
-		Value:  strconv.FormatInt(consensus.Block.MaxGas, 10),
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameConsensus,
-		Name:   "evidence_max_age_num_blocks",
-		Value:  strconv.FormatInt(consensus.Evidence.MaxAgeNumBlocks, 10),
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameConsensus,
-		Name:   "evidence_max_bytes",
-		Value:  strconv.FormatInt(consensus.Evidence.MaxBytes, 10),
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameConsensus,
-		Name:   "evidence_max_age_duration",
-		Value:  strconv.FormatInt(consensus.Evidence.MaxAgeDuration.Nanoseconds(), 10),
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameConsensus,
-		Name:   "validator_pub_key_types",
-		Value:  strings.Join(consensus.Validator.PubKeyTypes, ", "),
-	})
+	ctx.AddConstant(
+		storageTypes.ModuleNameConsensus,
+		"block_max_bytes",
+		strconv.FormatInt(consensus.Block.MaxBytes, 10),
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameConsensus,
+		"block_max_gas",
+		strconv.FormatInt(consensus.Block.MaxGas, 10),
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameConsensus,
+		"evidence_max_age_num_blocks",
+		strconv.FormatInt(consensus.Evidence.MaxAgeNumBlocks, 10),
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameConsensus,
+		"evidence_max_bytes",
+		strconv.FormatInt(consensus.Evidence.MaxBytes, 10),
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameConsensus,
+		"evidence_max_age_duration",
+		strconv.FormatInt(consensus.Evidence.MaxAgeDuration.Nanoseconds(), 10),
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameConsensus,
+		"validator_pub_key_types",
+		strings.Join(consensus.Validator.PubKeyTypes, ", "),
+	)
 
 	// auth
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameAuth,
-		Name:   "max_memo_characters",
-		Value:  appState.Auth.Params.MaxMemoCharacters,
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameAuth,
-		Name:   "tx_sig_limit",
-		Value:  appState.Auth.Params.TxSigLimit,
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameAuth,
-		Name:   "tx_size_cost_per_byte",
-		Value:  appState.Auth.Params.TxSizeCostPerByte,
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameAuth,
-		Name:   "sig_verify_cost_ed25519",
-		Value:  appState.Auth.Params.SigVerifyCostEd25519,
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameAuth,
-		Name:   "sig_verify_cost_secp256k1",
-		Value:  appState.Auth.Params.SigVerifyCostSecp256K1,
-	})
+	ctx.AddConstant(
+		storageTypes.ModuleNameAuth,
+		"max_memo_characters",
+		appState.Auth.Params.MaxMemoCharacters,
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameAuth,
+		"tx_sig_limit",
+		appState.Auth.Params.TxSigLimit,
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameAuth,
+		"tx_size_cost_per_byte",
+		appState.Auth.Params.TxSizeCostPerByte,
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameAuth,
+		"sig_verify_cost_ed25519",
+		appState.Auth.Params.SigVerifyCostEd25519,
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameAuth,
+		"sig_verify_cost_secp256k1",
+		appState.Auth.Params.SigVerifyCostSecp256K1,
+	)
 
 	// blob
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameBlob,
-		Name:   "gas_per_blob_byte",
-		Value:  strconv.FormatInt(int64(appState.Blob.Params.GasPerBlobByte), 10),
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameBlob,
-		Name:   "gov_max_square_size",
-		Value:  appState.Blob.Params.GovMaxSquareSize,
-	})
+	ctx.AddConstant(
+		storageTypes.ModuleNameBlob,
+		"gas_per_blob_byte",
+		strconv.FormatInt(int64(appState.Blob.Params.GasPerBlobByte), 10),
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameBlob,
+		"gov_max_square_size",
+		appState.Blob.Params.GovMaxSquareSize,
+	)
 
 	// crisis
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameCrisis,
-		Name:   "constant_fee",
-		Value:  appState.Crisis.ConstantFee.String(),
-	})
+	ctx.AddConstant(
+		storageTypes.ModuleNameCrisis,
+		"constant_fee",
+		appState.Crisis.ConstantFee.String(),
+	)
 
 	// distribution
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameDistribution,
-		Name:   "community_tax",
-		Value:  appState.Distribution.Params.CommunityTax,
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameDistribution,
-		Name:   "base_proposer_reward",
-		Value:  appState.Distribution.Params.BaseProposerReward,
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameDistribution,
-		Name:   "bonus_proposer_reward",
-		Value:  appState.Distribution.Params.BonusProposerReward,
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameDistribution,
-		Name:   "withdraw_addr_enabled",
-		Value:  strconv.FormatBool(appState.Distribution.Params.WithdrawAddrEnabled),
-	})
+	ctx.AddConstant(
+		storageTypes.ModuleNameDistribution,
+		"community_tax",
+		appState.Distribution.Params.CommunityTax,
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameDistribution,
+		"base_proposer_reward",
+		appState.Distribution.Params.BaseProposerReward,
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameDistribution,
+		"bonus_proposer_reward",
+		appState.Distribution.Params.BonusProposerReward,
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameDistribution,
+		"withdraw_addr_enabled",
+		strconv.FormatBool(appState.Distribution.Params.WithdrawAddrEnabled),
+	)
 
 	// gov
 	govDepositParams, err := appState.Gov.GetDepositParams()
@@ -123,11 +123,11 @@ func (module *Module) parseConstants(appState types.AppState, consensus pkgTypes
 	}
 
 	if len(govDepositParams.MinDeposit) > 0 {
-		data.constants = append(data.constants, storage.Constant{
-			Module: storageTypes.ModuleNameGov,
-			Name:   "min_deposit",
-			Value:  govDepositParams.MinDeposit[0].String(),
-		})
+		ctx.AddConstant(
+			storageTypes.ModuleNameGov,
+			"min_deposit",
+			govDepositParams.MinDeposit[0].String(),
+		)
 	}
 
 	maxDepositPeriod, err := time.ParseDuration(govDepositParams.MaxDepositPeriod)
@@ -135,11 +135,11 @@ func (module *Module) parseConstants(appState types.AppState, consensus pkgTypes
 		return errors.Wrap(err, "max deposit period")
 	}
 
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameGov,
-		Name:   "max_deposit_period",
-		Value:  strconv.FormatInt(maxDepositPeriod.Nanoseconds(), 10),
-	})
+	ctx.AddConstant(
+		storageTypes.ModuleNameGov,
+		"max_deposit_period",
+		strconv.FormatInt(maxDepositPeriod.Nanoseconds(), 10),
+	)
 
 	votingParams, err := appState.Gov.GetVotingParams()
 	if err != nil {
@@ -150,62 +150,62 @@ func (module *Module) parseConstants(appState types.AppState, consensus pkgTypes
 		return errors.Wrap(err, "voting period")
 	}
 
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameGov,
-		Name:   "voting_period",
-		Value:  strconv.FormatInt(votingPeriod.Nanoseconds(), 10),
-	})
+	ctx.AddConstant(
+		storageTypes.ModuleNameGov,
+		"voting_period",
+		strconv.FormatInt(votingPeriod.Nanoseconds(), 10),
+	)
 
 	tallyParams, err := appState.Gov.GetTallyParams()
 	if err != nil {
 		return err
 	}
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameGov,
-		Name:   "quorum",
-		Value:  tallyParams.Quorum,
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameGov,
-		Name:   "threshold",
-		Value:  tallyParams.Threshold,
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameGov,
-		Name:   "veto_threshold",
-		Value:  tallyParams.VetoThreshold,
-	})
+	ctx.AddConstant(
+		storageTypes.ModuleNameGov,
+		"quorum",
+		tallyParams.Quorum,
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameGov,
+		"threshold",
+		tallyParams.Threshold,
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameGov,
+		"veto_threshold",
+		tallyParams.VetoThreshold,
+	)
 
 	// slashing
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameSlashing,
-		Name:   "signed_blocks_window",
-		Value:  appState.Slashing.Params.SignedBlocksWindow,
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameSlashing,
-		Name:   "min_signed_per_window",
-		Value:  appState.Slashing.Params.MinSignedPerWindow,
-	})
+	ctx.AddConstant(
+		storageTypes.ModuleNameSlashing,
+		"signed_blocks_window",
+		appState.Slashing.Params.SignedBlocksWindow,
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameSlashing,
+		"min_signed_per_window",
+		appState.Slashing.Params.MinSignedPerWindow,
+	)
 	downtimeJailDuration, err := time.ParseDuration(appState.Slashing.Params.DowntimeJailDuration)
 	if err != nil {
 		return errors.Wrap(err, "DowntimeJailDuration")
 	}
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameSlashing,
-		Name:   "downtime_jail_duration",
-		Value:  strconv.FormatInt(downtimeJailDuration.Nanoseconds(), 10),
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameSlashing,
-		Name:   "slash_fraction_double_sign",
-		Value:  appState.Slashing.Params.SlashFractionDoubleSign,
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameSlashing,
-		Name:   "slash_fraction_downtime",
-		Value:  appState.Slashing.Params.SlashFractionDowntime,
-	})
+	ctx.AddConstant(
+		storageTypes.ModuleNameSlashing,
+		"downtime_jail_duration",
+		strconv.FormatInt(downtimeJailDuration.Nanoseconds(), 10),
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameSlashing,
+		"slash_fraction_double_sign",
+		appState.Slashing.Params.SlashFractionDoubleSign,
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameSlashing,
+		"slash_fraction_downtime",
+		appState.Slashing.Params.SlashFractionDowntime,
+	)
 
 	// staking
 	unbondingTime, err := time.ParseDuration(appState.Staking.Params.UnbondingTime)
@@ -213,36 +213,43 @@ func (module *Module) parseConstants(appState types.AppState, consensus pkgTypes
 		return errors.Wrap(err, "unbonding time")
 	}
 
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameStaking,
-		Name:   "unbonding_time",
-		Value:  strconv.FormatInt(unbondingTime.Nanoseconds(), 10),
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameStaking,
-		Name:   "max_validators",
-		Value:  strconv.FormatInt(int64(appState.Staking.Params.MaxValidators), 10),
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameStaking,
-		Name:   "max_entries",
-		Value:  strconv.FormatInt(int64(appState.Staking.Params.MaxEntries), 10),
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameStaking,
-		Name:   "historical_entries",
-		Value:  strconv.FormatInt(int64(appState.Staking.Params.HistoricalEntries), 10),
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameStaking,
-		Name:   "bond_denom",
-		Value:  appState.Staking.Params.BondDenom,
-	})
-	data.constants = append(data.constants, storage.Constant{
-		Module: storageTypes.ModuleNameStaking,
-		Name:   "min_commission_rate",
-		Value:  appState.Staking.Params.MinCommissionRate,
-	})
+	ctx.AddConstant(
+		storageTypes.ModuleNameStaking,
+		"unbonding_time",
+		strconv.FormatInt(unbondingTime.Nanoseconds(), 10),
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameStaking,
+		"max_validators",
+		strconv.FormatInt(int64(appState.Staking.Params.MaxValidators), 10),
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameStaking,
+		"max_entries",
+		strconv.FormatInt(int64(appState.Staking.Params.MaxEntries), 10),
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameStaking,
+		"historical_entries",
+		strconv.FormatInt(int64(appState.Staking.Params.HistoricalEntries), 10),
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameStaking,
+		"bond_denom",
+		appState.Staking.Params.BondDenom,
+	)
+	ctx.AddConstant(
+		storageTypes.ModuleNameStaking,
+		"min_commission_rate",
+		appState.Staking.Params.MinCommissionRate,
+	)
+
+	// minfee
+	ctx.AddConstant(
+		storageTypes.ModuleNameMinfee,
+		"network_min_gas_price",
+		appState.MinFee.NetworkMinGasPrice,
+	)
 
 	return nil
 }

--- a/pkg/indexer/genesis/constant.go
+++ b/pkg/indexer/genesis/constant.go
@@ -248,7 +248,7 @@ func (module *Module) parseConstants(ctx *decodeContext.Context, appState types.
 	ctx.AddConstant(
 		storageTypes.ModuleNameMinfee,
 		"network_min_gas_price",
-		appState.MinFee.NetworkMinGasPrice,
+		appState.MinFee.GetNetworkMinGasPrice(),
 	)
 
 	return nil

--- a/pkg/indexer/genesis/constant_test.go
+++ b/pkg/indexer/genesis/constant_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const notADuration = "not-a-duration"
+
 func mustNanos(t *testing.T, s string) string {
 	t.Helper()
 	d, err := time.ParseDuration(s)
@@ -191,25 +193,25 @@ func TestParseConstants_InvalidDuration(t *testing.T) {
 		{
 			name: "max_deposit_period",
 			mutate: func(a *types.AppState) {
-				a.Gov.Params.MaxDepositPeriod = "not-a-duration"
+				a.Gov.Params.MaxDepositPeriod = notADuration
 			},
 		},
 		{
 			name: "voting_period",
 			mutate: func(a *types.AppState) {
-				a.Gov.Params.VotingPeriod = "not-a-duration"
+				a.Gov.Params.VotingPeriod = notADuration
 			},
 		},
 		{
 			name: "downtime_jail_duration",
 			mutate: func(a *types.AppState) {
-				a.Slashing.Params.DowntimeJailDuration = "not-a-duration"
+				a.Slashing.Params.DowntimeJailDuration = notADuration
 			},
 		},
 		{
 			name: "unbonding_time",
 			mutate: func(a *types.AppState) {
-				a.Staking.Params.UnbondingTime = "not-a-duration"
+				a.Staking.Params.UnbondingTime = notADuration
 			},
 		},
 	}

--- a/pkg/indexer/genesis/constant_test.go
+++ b/pkg/indexer/genesis/constant_test.go
@@ -229,6 +229,17 @@ func TestParseConstants_InvalidDuration(t *testing.T) {
 	}
 }
 
+func TestParseConstants_MinFeeNewParamsFormatTakesPriority(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+	ctx := decodeContext.NewContext()
+	appState := testAppState()
+	appState.MinFee.Params.NetworkMinGasPrice = "0.00002"
+
+	err := module.parseConstants(ctx, appState, testConsensusParams())
+	require.NoError(t, err)
+	require.Equal(t, "0.00002", constantsMap(ctx)["minfee.network_min_gas_price"])
+}
+
 func TestParseConstants_MissingGovParams(t *testing.T) {
 	module := NewModule(postgres.Storage{}, config.Indexer{})
 	ctx := decodeContext.NewContext()

--- a/pkg/indexer/genesis/constant_test.go
+++ b/pkg/indexer/genesis/constant_test.go
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: 2025 Bb Strategy Pte. Ltd. <celenium@baking-bad.org>
+// SPDX-License-Identifier: MIT
+
+package genesis
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/celenium-io/celestia-indexer/internal/storage/postgres"
+	"github.com/celenium-io/celestia-indexer/pkg/indexer/config"
+	decodeContext "github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
+	"github.com/celenium-io/celestia-indexer/pkg/node/types"
+	pkgTypes "github.com/celenium-io/celestia-indexer/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func mustNanos(t *testing.T, s string) string {
+	t.Helper()
+	d, err := time.ParseDuration(s)
+	require.NoError(t, err)
+	return strconv.FormatInt(d.Nanoseconds(), 10)
+}
+
+func testAppState() types.AppState {
+	return types.AppState{
+		Auth: types.Auth{
+			Params: types.AuthParams{
+				MaxMemoCharacters:      "256",
+				TxSigLimit:             "7",
+				TxSizeCostPerByte:      "10",
+				SigVerifyCostEd25519:   "590",
+				SigVerifyCostSecp256K1: "1000",
+			},
+		},
+		Blob: types.BlobState{
+			Params: types.BlobParams{
+				GasPerBlobByte:   8,
+				GovMaxSquareSize: "64",
+			},
+		},
+		Crisis: types.Crisis{
+			ConstantFee: types.Coins{Denom: "utia", Amount: "1000"},
+		},
+		Distribution: types.Distribution{
+			Params: types.DistributionParams{
+				CommunityTax:        "0.02",
+				BaseProposerReward:  "0",
+				BonusProposerReward: "0",
+				WithdrawAddrEnabled: true,
+			},
+		},
+		Gov: types.Gov{
+			Params: &types.GovParams{
+				MinDeposit:       []types.Coins{{Denom: "utia", Amount: "10000000"}},
+				MaxDepositPeriod: "172800s",
+				VotingPeriod:     "115200s",
+				Quorum:           "0.334",
+				Threshold:        "0.5",
+				VetoThreshold:    "0.334",
+			},
+		},
+		Slashing: types.Slashing{
+			Params: types.SlashingParams{
+				SignedBlocksWindow:      "5000",
+				MinSignedPerWindow:      "0.1",
+				DowntimeJailDuration:    "600s",
+				SlashFractionDoubleSign: "0.05",
+				SlashFractionDowntime:   "0.01",
+			},
+		},
+		Staking: types.Staking{
+			Params: types.StakingParams{
+				UnbondingTime:     "1814400s",
+				MaxValidators:     100,
+				MaxEntries:        7,
+				HistoricalEntries: 10000,
+				BondDenom:         "utia",
+				MinCommissionRate: "0.05",
+			},
+		},
+		MinFee: types.MinFee{
+			NetworkMinGasPrice: "0.000001",
+		},
+	}
+}
+
+func testConsensusParams() pkgTypes.ConsensusParams {
+	return pkgTypes.ConsensusParams{
+		Block: &pkgTypes.BlockParams{
+			MaxBytes: 21000000,
+			MaxGas:   -1,
+		},
+		Evidence: &pkgTypes.EvidenceParams{
+			MaxAgeNumBlocks: 100000,
+			MaxAgeDuration:  48 * time.Hour,
+			MaxBytes:        1048576,
+		},
+		Validator: &pkgTypes.ValidatorParams{
+			PubKeyTypes: []string{"ed25519", "secp256k1"},
+		},
+	}
+}
+
+// constantsMap materializes ctx.Constants into "module.name" -> value for comparison.
+func constantsMap(ctx *decodeContext.Context) map[string]string {
+	got := make(map[string]string, ctx.Constants.Len())
+	for _, c := range ctx.Constants.Values() {
+		got[fmt.Sprintf("%s.%s", c.Module, c.Name)] = c.Value
+	}
+	return got
+}
+
+func TestParseConstants(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+	ctx := decodeContext.NewContext()
+	appState := testAppState()
+	consensus := testConsensusParams()
+
+	err := module.parseConstants(ctx, appState, consensus)
+	require.NoError(t, err)
+
+	want := map[string]string{
+		"consensus.block_max_bytes":             "21000000",
+		"consensus.block_max_gas":               "-1",
+		"consensus.evidence_max_age_num_blocks": "100000",
+		"consensus.evidence_max_bytes":          "1048576",
+		"consensus.evidence_max_age_duration":   strconv.FormatInt((48 * time.Hour).Nanoseconds(), 10),
+		"consensus.validator_pub_key_types":     "ed25519, secp256k1",
+
+		"auth.max_memo_characters":       "256",
+		"auth.tx_sig_limit":              "7",
+		"auth.tx_size_cost_per_byte":     "10",
+		"auth.sig_verify_cost_ed25519":   "590",
+		"auth.sig_verify_cost_secp256k1": "1000",
+
+		"blob.gas_per_blob_byte":   "8",
+		"blob.gov_max_square_size": "64",
+
+		"crisis.constant_fee": "1000utia",
+
+		"distribution.community_tax":         "0.02",
+		"distribution.base_proposer_reward":  "0",
+		"distribution.bonus_proposer_reward": "0",
+		"distribution.withdraw_addr_enabled": "true",
+
+		"gov.min_deposit":        "10000000utia",
+		"gov.max_deposit_period": mustNanos(t, "172800s"),
+		"gov.voting_period":      mustNanos(t, "115200s"),
+		"gov.quorum":             "0.334",
+		"gov.threshold":          "0.5",
+		"gov.veto_threshold":     "0.334",
+
+		"slashing.signed_blocks_window":       "5000",
+		"slashing.min_signed_per_window":      "0.1",
+		"slashing.downtime_jail_duration":     mustNanos(t, "600s"),
+		"slashing.slash_fraction_double_sign": "0.05",
+		"slashing.slash_fraction_downtime":    "0.01",
+
+		"staking.unbonding_time":      mustNanos(t, "1814400s"),
+		"staking.max_validators":      "100",
+		"staking.max_entries":         "7",
+		"staking.historical_entries":  "10000",
+		"staking.bond_denom":          "utia",
+		"staking.min_commission_rate": "0.05",
+
+		"minfee.network_min_gas_price": "0.000001",
+	}
+
+	require.Equal(t, want, constantsMap(ctx))
+}
+
+func TestParseConstants_ZeroMinDepositOmitted(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+	ctx := decodeContext.NewContext()
+	appState := testAppState()
+	appState.Gov.Params.MinDeposit = nil
+
+	err := module.parseConstants(ctx, appState, testConsensusParams())
+	require.NoError(t, err)
+	require.NotContains(t, constantsMap(ctx), "gov.min_deposit")
+}
+
+func TestParseConstants_InvalidDuration(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*types.AppState)
+	}{
+		{
+			name: "max_deposit_period",
+			mutate: func(a *types.AppState) {
+				a.Gov.Params.MaxDepositPeriod = "not-a-duration"
+			},
+		},
+		{
+			name: "voting_period",
+			mutate: func(a *types.AppState) {
+				a.Gov.Params.VotingPeriod = "not-a-duration"
+			},
+		},
+		{
+			name: "downtime_jail_duration",
+			mutate: func(a *types.AppState) {
+				a.Slashing.Params.DowntimeJailDuration = "not-a-duration"
+			},
+		},
+		{
+			name: "unbonding_time",
+			mutate: func(a *types.AppState) {
+				a.Staking.Params.UnbondingTime = "not-a-duration"
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			module := NewModule(postgres.Storage{}, config.Indexer{})
+			ctx := decodeContext.NewContext()
+			appState := testAppState()
+			tc.mutate(&appState)
+
+			err := module.parseConstants(ctx, appState, testConsensusParams())
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestParseConstants_MissingGovParams(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+	ctx := decodeContext.NewContext()
+	appState := testAppState()
+	appState.Gov.Params = nil
+
+	err := module.parseConstants(ctx, appState, testConsensusParams())
+	require.Error(t, err)
+}

--- a/pkg/indexer/genesis/denom_metadata.go
+++ b/pkg/indexer/genesis/denom_metadata.go
@@ -5,10 +5,11 @@ package genesis
 
 import (
 	"github.com/celenium-io/celestia-indexer/internal/storage"
+	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/celenium-io/celestia-indexer/pkg/node/types"
 )
 
-func (module *Module) parseDenomMetadata(raw []types.DenomMetadata, data *parsedData) {
+func (module *Module) parseDenomMetadata(decodeCtx *context.Context, raw []types.DenomMetadata) {
 	for i := range raw {
 		dm := storage.DenomMetadata{
 			Description: raw[i].Description,
@@ -19,6 +20,6 @@ func (module *Module) parseDenomMetadata(raw []types.DenomMetadata, data *parsed
 			Uri:         raw[i].URI,
 			Units:       raw[i].DenomUnits,
 		}
-		data.denomMetadata = append(data.denomMetadata, dm)
+		decodeCtx.AddDenomMetadata(dm)
 	}
 }

--- a/pkg/indexer/genesis/genesis.go
+++ b/pkg/indexer/genesis/genesis.go
@@ -83,12 +83,14 @@ func (module *Module) listen(ctx context.Context) {
 			decodeContext, err := module.parse(genesis)
 			if err != nil {
 				module.Log.Err(err).Msgf("parsing genesis block")
+				module.MustOutput(StopOutput).Push(struct{}{})
 				return
 			}
 			module.Log.Info().Msg("parsed genesis message")
 
 			if err := module.save(ctx, decodeContext); err != nil {
 				module.Log.Err(err).Msg("saving genesis block error")
+				module.MustOutput(StopOutput).Push(struct{}{})
 				return
 			}
 			module.Log.Info().Msg("saved genesis message")

--- a/pkg/indexer/genesis/genesis.go
+++ b/pkg/indexer/genesis/genesis.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage/postgres"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/config"
+	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode"
 	"github.com/celenium-io/celestia-indexer/pkg/node/types"
+	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/dipdup-net/indexer-sdk/pkg/modules"
 )
 
@@ -28,7 +30,9 @@ const (
 //	                     |----------------|
 type Module struct {
 	modules.BaseModule
-	storage     postgres.Storage
+	storage postgres.Storage
+	codec   *codec.ProtoCodec
+
 	indexerName string
 }
 
@@ -40,6 +44,7 @@ func NewModule(pg postgres.Storage, cfg config.Indexer) Module {
 		BaseModule:  modules.New("genesis"),
 		storage:     pg,
 		indexerName: cfg.Name,
+		codec:       codec.NewProtoCodec(decode.Config.InterfaceRegistry),
 	}
 
 	m.CreateInput(InputName)
@@ -75,14 +80,14 @@ func (module *Module) listen(ctx context.Context) {
 
 			module.Log.Info().Msg("received genesis message")
 
-			block, err := module.parse(genesis)
+			decodeContext, err := module.parse(genesis)
 			if err != nil {
 				module.Log.Err(err).Msgf("parsing genesis block")
 				return
 			}
 			module.Log.Info().Msg("parsed genesis message")
 
-			if err := module.save(ctx, block); err != nil {
+			if err := module.save(ctx, decodeContext); err != nil {
 				module.Log.Err(err).Msg("saving genesis block error")
 				return
 			}

--- a/pkg/indexer/genesis/genesis_test.go
+++ b/pkg/indexer/genesis/genesis_test.go
@@ -4,6 +4,7 @@
 package genesis
 
 import (
+	"context"
 	encjson "encoding/json"
 	"os"
 	"testing"
@@ -17,6 +18,7 @@ import (
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/config"
 	decodeContext "github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/celenium-io/celestia-indexer/pkg/node/types"
+	"github.com/dipdup-net/indexer-sdk/pkg/modules"
 	"github.com/stretchr/testify/require"
 )
 
@@ -251,4 +253,43 @@ func TestParse_FeegrantAndAuthzGrants_NoDuplication(t *testing.T) {
 	}
 	require.True(t, haveFee, "feegrant entry must be present exactly once")
 	require.True(t, haveAuthz, "authz entry must be present exactly once")
+}
+
+// Regression guard: listen() used to swallow parse errors by just logging and
+// returning, leaving the pipeline stuck instead of unblocking downstream modules
+// (e.g. the stopper) via StopOutput.
+func TestModule_OnParseError_PushesStopOutput(t *testing.T) {
+	writerModule := modules.New("writer-module")
+	outputName := "write"
+	writerModule.CreateOutput(outputName)
+
+	genesisModule := NewModule(postgres.Storage{}, config.Indexer{})
+	err := genesisModule.AttachTo(&writerModule, outputName, InputName)
+	require.NoError(t, err)
+
+	stopperModule := modules.New("stopper-module")
+	stopInputName := "stop-signal"
+	stopperModule.CreateInput(stopInputName)
+	err = stopperModule.AttachTo(&genesisModule, StopOutput, stopInputName)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	genesisModule.Start(ctx)
+
+	// an account with an unrecognized type makes module.parse fail immediately.
+	genesisOutput := types.GenesisOutput{
+		ModuleAccs: []types.Account{
+			{Type: "unknown-account-type"},
+		},
+	}
+	writerModule.MustOutput(outputName).Push(genesisOutput)
+
+	select {
+	case <-ctx.Done():
+		t.Error("stop by cancelled context")
+	case msg := <-stopperModule.MustInput(stopInputName).Listen():
+		require.Equal(t, struct{}{}, msg)
+	}
 }

--- a/pkg/indexer/genesis/genesis_test.go
+++ b/pkg/indexer/genesis/genesis_test.go
@@ -4,6 +4,7 @@
 package genesis
 
 import (
+	encjson "encoding/json"
 	"os"
 	"testing"
 	"time"
@@ -14,11 +15,22 @@ import (
 	"github.com/celenium-io/celestia-indexer/internal/storage/postgres"
 	storageTypes "github.com/celenium-io/celestia-indexer/internal/storage/types"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/config"
+	decodeContext "github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/celenium-io/celestia-indexer/pkg/node/types"
 	"github.com/stretchr/testify/require"
 )
 
 const permanentLockedAccountAddress = "celestia1j33593mn9urzydakw06jdun8f37shlucmhr8p6"
+
+// addressesMap materializes ctx.Addresses (a sync map) into a plain map so it can be
+// compared with require.Equal.
+func addressesMap(ctx *decodeContext.Context) map[string]*storage.Address {
+	got := make(map[string]*storage.Address, ctx.Addresses.Len())
+	for key, addr := range ctx.Addresses.All() {
+		got[key] = addr
+	}
+	return got
+}
 
 func TestParseAccounts(t *testing.T) {
 	f, err := os.Open("../../../test/json/genesis.json")
@@ -29,16 +41,19 @@ func TestParseAccounts(t *testing.T) {
 	err = json.ConfigFastest.NewDecoder(f).Decode(&g)
 	require.NoError(t, err)
 
-	data := newParsedData()
-
 	module := NewModule(postgres.Storage{}, config.Indexer{})
 
-	module.parseDenomMetadata(g.AppState.Bank.DenomMetadata, &data)
-
-	err = module.parseAccounts(g.AppState.Auth.Accounts, storage.Block{
+	ctx := decodeContext.NewContext()
+	block := storage.Block{
 		Height: 1,
 		Time:   time.Now(),
-	}, &data)
+	}
+	ctx.Block = &block
+
+	module.parseDenomMetadata(ctx, g.AppState.Bank.DenomMetadata)
+	denom := getBaseCurrency(ctx.DenomMetadata)
+
+	err = module.parseAccounts(ctx, denom, g.AppState.Auth.Accounts)
 	require.NoError(t, err)
 
 	want := map[string]*storage.Address{
@@ -86,11 +101,11 @@ func TestParseAccounts(t *testing.T) {
 			Balances:   []storage.Balance{storage.EmptyBalance()},
 		},
 	}
-	require.Equal(t, want, data.addresses)
-	require.Len(t, data.vestings, 4)
+	require.Equal(t, want, addressesMap(ctx))
+	require.Len(t, ctx.VestingAccounts, 4)
 
 	var permanent *storage.VestingAccount
-	for _, v := range data.vestings {
+	for _, v := range ctx.VestingAccounts {
 		if v.Address.Address == permanentLockedAccountAddress {
 			permanent = v
 			break
@@ -104,8 +119,11 @@ func TestParseAccounts(t *testing.T) {
 }
 
 func TestParseBalances_NewAddressMultiCoin(t *testing.T) {
-	data := newParsedData()
 	module := NewModule(postgres.Storage{}, config.Indexer{})
+
+	ctx := decodeContext.NewContext()
+	block := storage.Block{Height: 1}
+	ctx.Block = &block
 
 	const addr = "celestia1qqqpkhsnpyvtzx4knu53zsdfn7l88czztlp8tt"
 	balances := []types.Balances{
@@ -118,11 +136,11 @@ func TestParseBalances_NewAddressMultiCoin(t *testing.T) {
 		},
 	}
 
-	err := module.parseBalances(balances, 1, &data)
+	err := module.parseBalances(ctx, balances)
 	require.NoError(t, err)
 
-	require.Contains(t, data.addresses, addr)
-	got := data.addresses[addr]
+	got, ok := ctx.Addresses.Get(addr)
+	require.True(t, ok)
 	require.Len(t, got.Balances, 2)
 
 	byCurrency := make(map[string]storageTypes.Numeric)
@@ -133,17 +151,22 @@ func TestParseBalances_NewAddressMultiCoin(t *testing.T) {
 	require.Equal(t, storageTypes.NumericFromInt64(50), byCurrency["ibc/AAA"])
 }
 
+// Regression guard: parseBalances must mutate an existing address in place, not
+// re-run it through ctx.AddAddress, which would double every balance it just set.
 func TestParseBalances_ExistingAddressNewCurrency(t *testing.T) {
-	data := newParsedData()
 	module := NewModule(postgres.Storage{}, config.Indexer{})
 
+	ctx := decodeContext.NewContext()
+	block := storage.Block{Height: 1}
+	ctx.Block = &block
+
 	const addr = "celestia1qqqpkhsnpyvtzx4knu53zsdfn7l88czztlp8tt"
-	data.addresses[addr] = &storage.Address{
+	ctx.Addresses.Set(addr, &storage.Address{
 		Address:    addr,
 		Height:     1,
 		LastHeight: 1,
 		Balances:   []storage.Balance{storage.EmptyBalance()},
-	}
+	})
 
 	balances := []types.Balances{
 		{
@@ -155,10 +178,11 @@ func TestParseBalances_ExistingAddressNewCurrency(t *testing.T) {
 		},
 	}
 
-	err := module.parseBalances(balances, 1, &data)
+	err := module.parseBalances(ctx, balances)
 	require.NoError(t, err)
 
-	got := data.addresses[addr]
+	got, ok := ctx.Addresses.Get(addr)
+	require.True(t, ok)
 	require.Len(t, got.Balances, 2)
 
 	byCurrency := make(map[string]storageTypes.Numeric)
@@ -200,4 +224,31 @@ func TestParse_NonExportedGenesisSucceeds(t *testing.T) {
 	module := NewModule(postgres.Storage{}, config.Indexer{})
 	_, err := module.parse(types.GenesisOutput{Genesis: g})
 	require.NoError(t, err)
+}
+
+// Regression guard: an earlier version had parseFeeGrants/parseAuthzGrants each
+// snapshot the shared ctx.Grants into data.grants, duplicating entries from the first call.
+func TestParse_FeegrantAndAuthzGrants_NoDuplication(t *testing.T) {
+	g := loadGenesisFixture(t)
+	g.AppState.Genutil.GenTxs = nil
+	g.AppState.Feegrant.FeeGrants = []encjson.RawMessage{encjson.RawMessage(basicAllowanceGrantJSON)}
+	g.AppState.Authz.Authorization = []encjson.RawMessage{encjson.RawMessage(sendAuthzGrantJSON)}
+
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+	dCtx, err := module.parse(types.GenesisOutput{Genesis: g})
+	require.NoError(t, err)
+
+	grants := dCtx.Grants.Values()
+	require.Len(t, grants, 2)
+	var haveFee, haveAuthz bool
+	for _, grant := range grants {
+		switch grant.Authorization {
+		case "fee":
+			haveFee = true
+		case "/cosmos.bank.v1beta1.MsgSend":
+			haveAuthz = true
+		}
+	}
+	require.True(t, haveFee, "feegrant entry must be present exactly once")
+	require.True(t, haveAuthz, "authz entry must be present exactly once")
 }

--- a/pkg/indexer/genesis/grants.go
+++ b/pkg/indexer/genesis/grants.go
@@ -7,36 +7,52 @@ import (
 	"encoding/json"
 
 	"cosmossdk.io/x/feegrant"
-	"github.com/celenium-io/celestia-indexer/internal/storage"
 	storageTypes "github.com/celenium-io/celestia-indexer/internal/storage/types"
-	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode"
 	decodeContext "github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/decode/handle"
-	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	"github.com/pkg/errors"
 )
 
 func (module *Module) parseFeeGrants(
-	feeGrantsRaw []json.RawMessage, block storage.Block, data *parsedData,
+	ctx *decodeContext.Context, feeGrantsRaw []json.RawMessage,
 ) error {
-	cdc := codec.NewProtoCodec(decode.Config.InterfaceRegistry)
-
-	ctx := decodeContext.NewContext()
-	ctx.Block = &block
 	for i := range feeGrantsRaw {
 		var feeGrant feegrant.MsgGrantAllowance
-		if err := cdc.UnmarshalJSON(feeGrantsRaw[i], &feeGrant); err != nil {
+		if err := module.codec.UnmarshalJSON(feeGrantsRaw[i], &feeGrant); err != nil {
 			return err
 		}
 		if _, err := handle.MsgGrantAllowance(ctx, storageTypes.StatusSuccess, 0, &feeGrant); err != nil {
 			return err
 		}
-		if err := addAddress(data, block, feeGrant.Grantee); err != nil {
+	}
+	return nil
+}
+
+func (module *Module) parseAuthzGrants(
+	ctx *decodeContext.Context, grantsRaw []json.RawMessage,
+) error {
+	for i := range grantsRaw {
+		var grant authz.GrantAuthorization
+		if err := module.codec.UnmarshalJSON(grantsRaw[i], &grant); err != nil {
 			return err
 		}
-		if err := addAddress(data, block, feeGrant.Granter); err != nil {
+		if grant.Authorization == nil {
+			return errors.Errorf("genesis authz grant has empty authorization: granter=%s grantee=%s",
+				grant.Granter, grant.Grantee)
+		}
+
+		msg := authz.MsgGrant{
+			Granter: grant.Granter,
+			Grantee: grant.Grantee,
+			Grant: authz.Grant{
+				Authorization: grant.Authorization,
+				Expiration:    grant.Expiration,
+			},
+		}
+		if _, err := handle.MsgGrant(ctx, storageTypes.StatusSuccess, 0, &msg); err != nil {
 			return err
 		}
 	}
-	data.grants = ctx.Grants.Values()
 	return nil
 }

--- a/pkg/indexer/genesis/grants_test.go
+++ b/pkg/indexer/genesis/grants_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/celenium-io/celestia-indexer/internal/storage/postgres"
 	storageTypes "github.com/celenium-io/celestia-indexer/internal/storage/types"
 	"github.com/celenium-io/celestia-indexer/pkg/indexer/config"
+	decodeContext "github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,7 +45,78 @@ const (
 			]
 		}
 	}`
+
+	genericAuthzGrantJSON = `{
+		"granter": "celestia18r6ujzzkg6ku9sr39nxy4847q4qea5kg4a8pxv",
+		"grantee": "celestia1llx8v3hhw06cmtmv7q7uq4ztgyvd33nmk7mrfh",
+		"authorization": {
+			"@type": "/cosmos.authz.v1beta1.GenericAuthorization",
+			"msg": "/cosmos.gov.v1.MsgVote"
+		},
+		"expiration": null
+	}`
+
+	sendAuthzGrantJSON = `{
+		"granter": "celestia1gezy6mf5hy5nmq445djq3s3mwx7pl2xe7r3kp6",
+		"grantee": "celestia1lamchvjp7c7d9asy8g9cxuycfa4qf4t6c3ufeg",
+		"authorization": {
+			"@type": "/cosmos.bank.v1beta1.SendAuthorization",
+			"spend_limit": [],
+			"allow_list": []
+		},
+		"expiration": null
+	}`
+
+	expiredSendAuthzGrantJSON = `{
+		"granter": "celestia1gezy6mf5hy5nmq445djq3s3mwx7pl2xe7r3kp6",
+		"grantee": "celestia1lamchvjp7c7d9asy8g9cxuycfa4qf4t6c3ufeg",
+		"authorization": {
+			"@type": "/cosmos.bank.v1beta1.SendAuthorization",
+			"spend_limit": [],
+			"allow_list": []
+		},
+		"expiration": "2000-01-01T00:00:00Z"
+	}`
+
+	nilAuthorizationGrantJSON = `{
+		"granter": "celestia1gezy6mf5hy5nmq445djq3s3mwx7pl2xe7r3kp6",
+		"grantee": "celestia1lamchvjp7c7d9asy8g9cxuycfa4qf4t6c3ufeg",
+		"expiration": null
+	}`
+
+	malformedAddressAuthzGrantJSON = `{
+		"granter": "not-a-valid-address",
+		"grantee": "celestia1lamchvjp7c7d9asy8g9cxuycfa4qf4t6c3ufeg",
+		"authorization": {
+			"@type": "/cosmos.bank.v1beta1.SendAuthorization",
+			"spend_limit": [],
+			"allow_list": []
+		},
+		"expiration": null
+	}`
+
+	unrecognizedTypeAuthzGrantJSON = `{
+		"granter": "celestia18r6ujzzkg6ku9sr39nxy4847q4qea5kg4a8pxv",
+		"grantee": "celestia1llx8v3hhw06cmtmv7q7uq4ztgyvd33nmk7mrfh",
+		"authorization": {
+			"@type": "/ibc.applications.transfer.v1.TransferAuthorization",
+			"allocations": []
+		},
+		"expiration": null
+	}`
 )
+
+func stakeAuthzGrantJSON(authorizationType string) string {
+	return `{
+		"granter": "celestia18r6ujzzkg6ku9sr39nxy4847q4qea5kg4a8pxv",
+		"grantee": "celestia1llx8v3hhw06cmtmv7q7uq4ztgyvd33nmk7mrfh",
+		"authorization": {
+			"@type": "/cosmos.staking.v1beta1.StakeAuthorization",
+			"authorization_type": "` + authorizationType + `"
+		},
+		"expiration": null
+	}`
+}
 
 func testBlock() storage.Block {
 	return storage.Block{
@@ -54,16 +126,18 @@ func testBlock() storage.Block {
 }
 
 func TestParseFeeGrants_BasicAllowance(t *testing.T) {
-	data := newParsedData()
 	module := NewModule(postgres.Storage{}, config.Indexer{})
 
 	raw := []json.RawMessage{[]byte(basicAllowanceGrantJSON)}
 	block := testBlock()
-	err := module.parseFeeGrants(raw, block, &data)
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	err := module.parseFeeGrants(ctx, raw)
 	require.NoError(t, err)
 
-	require.Len(t, data.grants, 1)
-	grant := data.grants[0]
+	grants := ctx.Grants.Values()
+	require.Len(t, grants, 1)
+	grant := grants[0]
 
 	require.Equal(t, "celestia18r6ujzzkg6ku9sr39nxy4847q4qea5kg4a8pxv", grant.Granter.Address)
 	require.Equal(t, "celestia1llx8v3hhw06cmtmv7q7uq4ztgyvd33nmk7mrfh", grant.Grantee.Address)
@@ -77,25 +151,31 @@ func TestParseFeeGrants_BasicAllowance(t *testing.T) {
 	require.True(t, ok)
 	require.Empty(t, spendLimit)
 
-	require.Contains(t, data.addresses, grant.Granter.Address)
-	require.Contains(t, data.addresses, grant.Grantee.Address)
+	_, ok = ctx.Addresses.Get(grant.Granter.Address)
+	require.True(t, ok)
+	_, ok = ctx.Addresses.Get(grant.Grantee.Address)
+	require.True(t, ok)
 
-	granterAddr := data.addresses[grant.Granter.Address]
+	granterAddr, ok := ctx.Addresses.Get(grant.Granter.Address)
+	require.True(t, ok)
 	require.Len(t, granterAddr.Balances, 1)
 	require.True(t, granterAddr.Balances[0].Spendable.IsZero())
 	require.Equal(t, currency.Utia, granterAddr.Balances[0].Currency)
 }
 
 func TestParseFeeGrants_AllowedMsgAllowance(t *testing.T) {
-	data := newParsedData()
 	module := NewModule(postgres.Storage{}, config.Indexer{})
 
 	raw := []json.RawMessage{[]byte(allowedMsgAllowanceGrantJSON)}
-	err := module.parseFeeGrants(raw, testBlock(), &data)
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	err := module.parseFeeGrants(ctx, raw)
 	require.NoError(t, err)
 
-	require.Len(t, data.grants, 1)
-	grant := data.grants[0]
+	grants := ctx.Grants.Values()
+	require.Len(t, grants, 1)
+	grant := grants[0]
 
 	require.Equal(t, "celestia1gezy6mf5hy5nmq445djq3s3mwx7pl2xe7r3kp6", grant.Granter.Address)
 	require.Equal(t, "celestia1lamchvjp7c7d9asy8g9cxuycfa4qf4t6c3ufeg", grant.Grantee.Address)
@@ -117,50 +197,60 @@ func TestParseFeeGrants_AllowedMsgAllowance(t *testing.T) {
 
 	require.Nil(t, grant.Expiration)
 
-	require.Contains(t, data.addresses, grant.Granter.Address)
-	require.Contains(t, data.addresses, grant.Grantee.Address)
+	_, ok = ctx.Addresses.Get(grant.Granter.Address)
+	require.True(t, ok)
+	_, ok = ctx.Addresses.Get(grant.Grantee.Address)
+	require.True(t, ok)
 }
 
 func TestParseFeeGrants_Multiple(t *testing.T) {
-	data := newParsedData()
 	module := NewModule(postgres.Storage{}, config.Indexer{})
 
 	raw := []json.RawMessage{
 		[]byte(basicAllowanceGrantJSON),
 		[]byte(allowedMsgAllowanceGrantJSON),
 	}
-	err := module.parseFeeGrants(raw, testBlock(), &data)
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	err := module.parseFeeGrants(ctx, raw)
 	require.NoError(t, err)
 
-	require.Len(t, data.grants, 2)
-	require.Len(t, data.addresses, 4)
+	require.Len(t, ctx.Grants.Values(), 2)
+	require.Equal(t, 4, ctx.Addresses.Len())
 }
 
 func TestParseFeeGrants_Empty(t *testing.T) {
-	data := newParsedData()
 	module := NewModule(postgres.Storage{}, config.Indexer{})
 
-	err := module.parseFeeGrants(nil, testBlock(), &data)
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	err := module.parseFeeGrants(ctx, nil)
 	require.NoError(t, err)
-	require.Empty(t, data.grants)
-	require.Empty(t, data.addresses)
+	require.Empty(t, ctx.Grants.Values())
+	require.Zero(t, ctx.Addresses.Len())
 }
 
 func TestParseFeeGrants_InvalidJSON(t *testing.T) {
-	data := newParsedData()
 	module := NewModule(postgres.Storage{}, config.Indexer{})
 
 	raw := []json.RawMessage{[]byte(`{"granter": "not valid`)}
-	err := module.parseFeeGrants(raw, testBlock(), &data)
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	err := module.parseFeeGrants(ctx, raw)
 	require.Error(t, err)
 }
 
 func TestParseFeeGrants_ExistingAddressKeepsBalance(t *testing.T) {
-	data := newParsedData()
 	module := NewModule(postgres.Storage{}, config.Indexer{})
 
 	const granterAddr = "celestia18r6ujzzkg6ku9sr39nxy4847q4qea5kg4a8pxv"
-	data.addresses[granterAddr] = &storage.Address{
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	ctx.Addresses.Set(granterAddr, &storage.Address{
 		Address: granterAddr,
 		Balances: []storage.Balance{
 			{
@@ -168,11 +258,279 @@ func TestParseFeeGrants_ExistingAddressKeepsBalance(t *testing.T) {
 				Spendable: storageTypes.NumericFromInt64(500),
 			},
 		},
-	}
+	})
 
 	raw := []json.RawMessage{[]byte(basicAllowanceGrantJSON)}
-	err := module.parseFeeGrants(raw, testBlock(), &data)
+	err := module.parseFeeGrants(ctx, raw)
 	require.NoError(t, err)
 
-	require.Equal(t, "500", data.addresses[granterAddr].Balances[0].Spendable.String())
+	granterAddress, ok := ctx.Addresses.Get(granterAddr)
+	require.True(t, ok)
+	require.Equal(t, "500", granterAddress.Balances[0].Spendable.String())
+}
+
+func TestParseAuthzGrants_GenericAuthorization(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+
+	raw := []json.RawMessage{[]byte(genericAuthzGrantJSON)}
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	err := module.parseAuthzGrants(ctx, raw)
+	require.NoError(t, err)
+
+	grants := ctx.Grants.Values()
+	require.Len(t, grants, 1)
+	grant := grants[0]
+
+	require.Equal(t, "celestia18r6ujzzkg6ku9sr39nxy4847q4qea5kg4a8pxv", grant.Granter.Address)
+	require.Equal(t, "celestia1llx8v3hhw06cmtmv7q7uq4ztgyvd33nmk7mrfh", grant.Grantee.Address)
+	require.Equal(t, "/cosmos.gov.v1.MsgVote", grant.Authorization)
+	require.NotNil(t, grant.Params)
+	require.False(t, grant.Revoked)
+	require.Nil(t, grant.Expiration)
+
+	_, ok := ctx.Addresses.Get(grant.Granter.Address)
+	require.True(t, ok)
+	_, ok = ctx.Addresses.Get(grant.Grantee.Address)
+	require.True(t, ok)
+}
+
+func TestParseAuthzGrants_SendAuthorization(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+
+	raw := []json.RawMessage{[]byte(sendAuthzGrantJSON)}
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	err := module.parseAuthzGrants(ctx, raw)
+	require.NoError(t, err)
+
+	grants := ctx.Grants.Values()
+	require.Len(t, grants, 1)
+	grant := grants[0]
+
+	require.Equal(t, "celestia1gezy6mf5hy5nmq445djq3s3mwx7pl2xe7r3kp6", grant.Granter.Address)
+	require.Equal(t, "celestia1lamchvjp7c7d9asy8g9cxuycfa4qf4t6c3ufeg", grant.Grantee.Address)
+	require.Equal(t, "/cosmos.bank.v1beta1.MsgSend", grant.Authorization)
+	require.NotNil(t, grant.Params)
+
+	_, ok := ctx.Addresses.Get(grant.Granter.Address)
+	require.True(t, ok)
+	_, ok = ctx.Addresses.Get(grant.Grantee.Address)
+	require.True(t, ok)
+}
+
+func TestParseAuthzGrants_StakeAuthorization(t *testing.T) {
+	cases := []struct {
+		name              string
+		authorizationType string
+		wantAuthorization []string
+	}{
+		{"Delegate", "AUTHORIZATION_TYPE_DELEGATE", []string{"/cosmos.staking.v1beta1.MsgDelegate"}},
+		{"Redelegate", "AUTHORIZATION_TYPE_REDELEGATE", []string{"/cosmos.staking.v1beta1.MsgRedelegate"}},
+		{"Undelegate", "AUTHORIZATION_TYPE_UNDELEGATE", []string{"/cosmos.staking.v1beta1.MsgUndelegate"}},
+		{"CancelUnbondingDelegation", "AUTHORIZATION_TYPE_CANCEL_UNBONDING_DELEGATION", []string{"/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation"}},
+		{"Unspecified", "AUTHORIZATION_TYPE_UNSPECIFIED", []string{
+			"/cosmos.staking.v1beta1.MsgDelegate",
+			"/cosmos.staking.v1beta1.MsgRedelegate",
+			"/cosmos.staking.v1beta1.MsgUndelegate",
+			"/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation",
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			module := NewModule(postgres.Storage{}, config.Indexer{})
+
+			raw := []json.RawMessage{[]byte(stakeAuthzGrantJSON(tc.authorizationType))}
+			block := testBlock()
+			ctx := decodeContext.NewContext()
+			ctx.Block = &block
+			err := module.parseAuthzGrants(ctx, raw)
+			require.NoError(t, err)
+
+			grants := ctx.Grants.Values()
+			require.Len(t, grants, len(tc.wantAuthorization))
+			got := make([]string, len(grants))
+			for i, g := range grants {
+				got[i] = g.Authorization
+			}
+			require.ElementsMatch(t, tc.wantAuthorization, got)
+		})
+	}
+}
+
+func TestParseAuthzGrants_Expiration(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+
+	raw := []json.RawMessage{[]byte(expiredSendAuthzGrantJSON)}
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	err := module.parseAuthzGrants(ctx, raw)
+	require.NoError(t, err)
+
+	grants := ctx.Grants.Values()
+	require.Len(t, grants, 1)
+	grant := grants[0]
+
+	require.NotNil(t, grant.Expiration)
+	require.True(t, grant.Expiration.Before(time.Now()), "expiration is in the past and must not be filtered out")
+	require.False(t, grant.Revoked)
+}
+
+func TestParseAuthzGrants_NilAuthorization(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+
+	raw := []json.RawMessage{[]byte(nilAuthorizationGrantJSON)}
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	err := module.parseAuthzGrants(ctx, raw)
+	require.Error(t, err)
+}
+
+// An unrecognized authorization type falls back to a generic grant (raw type URL,
+// no decoded Params) rather than being skipped or erroring out.
+func TestParseAuthzGrants_UnrecognizedType(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+
+	raw := []json.RawMessage{[]byte(unrecognizedTypeAuthzGrantJSON)}
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	err := module.parseAuthzGrants(ctx, raw)
+	require.NoError(t, err)
+
+	grants := ctx.Grants.Values()
+	require.Len(t, grants, 1)
+	grant := grants[0]
+	require.Equal(t, "/ibc.applications.transfer.v1.TransferAuthorization", grant.Authorization)
+	require.Nil(t, grant.Params)
+	require.Equal(t, "celestia18r6ujzzkg6ku9sr39nxy4847q4qea5kg4a8pxv", grant.Granter.Address)
+	require.Equal(t, "celestia1llx8v3hhw06cmtmv7q7uq4ztgyvd33nmk7mrfh", grant.Grantee.Address)
+}
+
+// Repeating the same grant JSON must not produce two grant rows: ctx.Grants dedups by
+// grant.String(), same key both times.
+func TestParseAuthzGrants_DuplicateKnownType(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+
+	raw := []json.RawMessage{[]byte(genericAuthzGrantJSON), []byte(genericAuthzGrantJSON)}
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	err := module.parseAuthzGrants(ctx, raw)
+	require.NoError(t, err)
+	require.Len(t, ctx.Grants.Values(), 1)
+}
+
+func TestParseAuthzGrants_Multiple(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+
+	raw := []json.RawMessage{
+		[]byte(genericAuthzGrantJSON),
+		[]byte(sendAuthzGrantJSON),
+	}
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	err := module.parseAuthzGrants(ctx, raw)
+	require.NoError(t, err)
+
+	require.Len(t, ctx.Grants.Values(), 2)
+	require.Equal(t, 4, ctx.Addresses.Len())
+}
+
+func TestParseAuthzGrants_Empty(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	err := module.parseAuthzGrants(ctx, nil)
+	require.NoError(t, err)
+	require.Empty(t, ctx.Grants.Values())
+	require.Zero(t, ctx.Addresses.Len())
+}
+
+func TestParseAuthzGrants_InvalidJSON(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+
+	raw := []json.RawMessage{[]byte(`{"granter": "not valid`)}
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	err := module.parseAuthzGrants(ctx, raw)
+	require.Error(t, err)
+}
+
+func TestParseAuthzGrants_MalformedAddress(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+
+	raw := []json.RawMessage{[]byte(malformedAddressAuthzGrantJSON)}
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	err := module.parseAuthzGrants(ctx, raw)
+	require.Error(t, err)
+}
+
+func TestParseAuthzGrants_ExistingAddressKeepsBalance(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+
+	const granterAddr = "celestia18r6ujzzkg6ku9sr39nxy4847q4qea5kg4a8pxv"
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+	ctx.Addresses.Set(granterAddr, &storage.Address{
+		Address: granterAddr,
+		Balances: []storage.Balance{
+			{
+				Currency:  currency.Utia,
+				Spendable: storageTypes.NumericFromInt64(500),
+			},
+		},
+	})
+
+	raw := []json.RawMessage{[]byte(genericAuthzGrantJSON)}
+	err := module.parseAuthzGrants(ctx, raw)
+	require.NoError(t, err)
+
+	granterAddress, ok := ctx.Addresses.Get(granterAddr)
+	require.True(t, ok)
+	require.Equal(t, "500", granterAddress.Balances[0].Spendable.String())
+}
+
+// Regression guard: feegrant and authz grants share ctx.Grants; neither parse call
+// may clobber entries the other already wrote.
+func TestParseGrants_MixedFeegrantAndAuthz_NoClobber(t *testing.T) {
+	module := NewModule(postgres.Storage{}, config.Indexer{})
+
+	block := testBlock()
+	ctx := decodeContext.NewContext()
+	ctx.Block = &block
+
+	feeRaw := []json.RawMessage{[]byte(basicAllowanceGrantJSON)}
+	err := module.parseFeeGrants(ctx, feeRaw)
+	require.NoError(t, err)
+
+	authzRaw := []json.RawMessage{[]byte(sendAuthzGrantJSON)}
+	err = module.parseAuthzGrants(ctx, authzRaw)
+	require.NoError(t, err)
+
+	grants := ctx.Grants.Values()
+	require.Len(t, grants, 2)
+	var haveFee, haveAuthz bool
+	for _, g := range grants {
+		switch g.Authorization {
+		case "fee":
+			haveFee = true
+		case "/cosmos.bank.v1beta1.MsgSend":
+			haveAuthz = true
+		}
+	}
+	require.True(t, haveFee, "feegrant entry must be present")
+	require.True(t, haveAuthz, "authz entry must be present")
 }

--- a/pkg/indexer/genesis/grants_test.go
+++ b/pkg/indexer/genesis/grants_test.go
@@ -391,7 +391,7 @@ func TestParseAuthzGrants_NilAuthorization(t *testing.T) {
 	require.Error(t, err)
 }
 
-// An unrecognized authorization type falls back to a generic grant (raw type URL,
+// An unrecognized authorization type falls back to a generic grant (unknown_type_url,
 // no decoded Params) rather than being skipped or erroring out.
 func TestParseAuthzGrants_UnrecognizedType(t *testing.T) {
 	module := NewModule(postgres.Storage{}, config.Indexer{})
@@ -406,7 +406,7 @@ func TestParseAuthzGrants_UnrecognizedType(t *testing.T) {
 	grants := ctx.Grants.Values()
 	require.Len(t, grants, 1)
 	grant := grants[0]
-	require.Equal(t, "/ibc.applications.transfer.v1.TransferAuthorization", grant.Authorization)
+	require.Equal(t, "unknown_type_url", grant.Authorization)
 	require.Nil(t, grant.Params)
 	require.Equal(t, "celestia18r6ujzzkg6ku9sr39nxy4847q4qea5kg4a8pxv", grant.Granter.Address)
 	require.Equal(t, "celestia1llx8v3hhw06cmtmv7q7uq4ztgyvd33nmk7mrfh", grant.Grantee.Address)

--- a/pkg/indexer/genesis/parse.go
+++ b/pkg/indexer/genesis/parse.go
@@ -20,6 +20,10 @@ import (
 )
 
 func (module *Module) parse(genesis types.GenesisOutput) (*context.Context, error) {
+	if genesis.AppState.Staking.Exported {
+		return nil, errors.New("genesis was produced by state export (app_state.staking.exported=true): validators and delegations are not read from gen_txs in this case and parsing them is not supported")
+	}
+
 	decodeCtx := context.NewContext()
 	decodeCtx.Block = &storage.Block{
 		Time:    genesis.GenesisTime,

--- a/pkg/indexer/genesis/parse.go
+++ b/pkg/indexer/genesis/parse.go
@@ -19,41 +19,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-type parsedData struct {
-	block         storage.Block
-	addresses     map[string]*storage.Address
-	validators    []*storage.Validator
-	stakingLogs   []storage.StakingLog
-	delegations   []storage.Delegation
-	constants     []storage.Constant
-	denomMetadata []storage.DenomMetadata
-	vestings      []*storage.VestingAccount
-	grants        []*storage.Grant
-
-	bondedTokensPool *storage.Address
-	feeCollector     *storage.Address
-}
-
-func newParsedData() parsedData {
-	return parsedData{
-		addresses:     make(map[string]*storage.Address),
-		validators:    make([]*storage.Validator, 0),
-		stakingLogs:   make([]storage.StakingLog, 0),
-		delegations:   make([]storage.Delegation, 0),
-		constants:     make([]storage.Constant, 0),
-		denomMetadata: make([]storage.DenomMetadata, 0),
-		vestings:      make([]*storage.VestingAccount, 0),
-		grants:        make([]*storage.Grant, 0),
-	}
-}
-
-func (module *Module) parse(genesis types.GenesisOutput) (parsedData, error) {
-	if genesis.AppState.Staking.Exported {
-		return parsedData{}, errors.New("genesis was produced by state export (app_state.staking.exported=true): validators and delegations are not read from gen_txs in this case and parsing them is not supported")
-	}
-
-	data := newParsedData()
-	block := storage.Block{
+func (module *Module) parse(genesis types.GenesisOutput) (*context.Context, error) {
+	decodeCtx := context.NewContext()
+	decodeCtx.Block = &storage.Block{
 		Time:    genesis.GenesisTime,
 		Height:  pkgTypes.Level(genesis.InitialHeight - 1),
 		AppHash: []byte(genesis.AppHash),
@@ -70,34 +38,46 @@ func (module *Module) parse(genesis types.GenesisOutput) (parsedData, error) {
 		},
 		MessageTypes: storageTypes.NewMsgTypeBits(),
 	}
-	module.parseDenomMetadata(genesis.AppState.Bank.DenomMetadata, &data)
 
-	decodeCtx := context.NewContext()
-	decodeCtx.Block = &block
-	currencyBase := getBaseCurrency(data.denomMetadata)
+	var (
+		bondedTokensPool *storage.Address
+		feeCollector     *storage.Address
+	)
 
-	if err := module.parseAccounts(genesis.ModuleAccs, block, &data); err != nil {
-		return data, errors.Wrap(err, "parse genesis accounts")
+	module.parseDenomMetadata(decodeCtx, genesis.AppState.Bank.DenomMetadata)
+	currencyBase := getBaseCurrency(decodeCtx.DenomMetadata)
+
+	if err := module.parseAccounts(decodeCtx, currencyBase, genesis.ModuleAccs); err != nil {
+		return decodeCtx, errors.Wrap(err, "parse genesis accounts")
+	}
+
+	for acc := range decodeCtx.Addresses.AllValues() {
+		switch acc.Name {
+		case "bonded_tokens_pool":
+			bondedTokensPool = acc
+		case "fee_collector":
+			feeCollector = acc
+		}
 	}
 
 	for index, genTx := range genesis.AppState.Genutil.GenTxs {
 		txDecoded, err := decode.JsonTx(genTx)
 		if err != nil {
-			return data, errors.Wrapf(err, "failed to decode GenTx '%s'", genTx)
+			return decodeCtx, errors.Wrapf(err, "failed to decode GenTx '%s'", genTx)
 		}
 
 		memoTx, ok := txDecoded.(cosmosTypes.TxWithMemo)
 		if !ok {
-			return data, errors.Wrapf(err, "expected TxWithMemo, got %T", genTx)
+			return decodeCtx, errors.Wrapf(err, "expected TxWithMemo, got %T", genTx)
 		}
 		txWithTimeoutHeight, ok := txDecoded.(cosmosTypes.TxWithTimeoutHeight)
 		if !ok {
-			return data, errors.Wrapf(err, "expected TxWithTimeoutHeight, got %T", genTx)
+			return decodeCtx, errors.Wrapf(err, "expected TxWithTimeoutHeight, got %T", genTx)
 		}
 
-		tx := &block.Txs[index]
-		tx.Height = block.Height
-		tx.Time = block.Time
+		tx := &decodeCtx.Block.Txs[index]
+		tx.Height = decodeCtx.Block.Height
+		tx.Time = decodeCtx.Block.Time
 		tx.Position = int64(index)
 		tx.TimeoutHeight = txWithTimeoutHeight.GetTimeoutHeight()
 		tx.MessagesCount = int64(len(txDecoded.GetMsgs()))
@@ -109,39 +89,39 @@ func (module *Module) parse(genesis types.GenesisOutput) (parsedData, error) {
 		tx.Events = nil
 
 		if err := tx.SetId(); err != nil {
-			return data, err
+			return decodeCtx, err
 		}
 
 		for msgIndex, msg := range txDecoded.GetMsgs() {
 			decoded, err := decode.Message(decodeCtx, msg, msgIndex, storageTypes.StatusSuccess, tx.Id)
 			if err != nil {
-				return data, errors.Wrap(err, "decode genesis message")
+				return decodeCtx, errors.Wrap(err, "decode genesis message")
 			}
 
 			tx.Messages[msgIndex] = decoded.Msg
 			tx.MessageTypes.SetByMsgType(decoded.Msg.Type)
-			block.MessageTypes.SetByMsgType(decoded.Msg.Type)
+			decodeCtx.Block.MessageTypes.SetByMsgType(decoded.Msg.Type)
 			tx.BlobsSize += decoded.BlobsSize
 		}
 
 		if t, ok := txDecoded.(cosmosTypes.FeeTx); ok {
 			value, err := decode.DecodeFee(t.GetFee())
 			if err != nil {
-				return data, errors.Wrap(err, "fee decoding")
+				return decodeCtx, errors.Wrap(err, "fee decoding")
 			}
 			tx.Fee = storageTypes.NewNumeric(value)
-			block.Stats.Fee = block.Stats.Fee.Add(tx.Fee)
-			if data.feeCollector != nil {
-				data.feeCollector.AddSpendableBalance(currencyBase, tx.Fee)
+			decodeCtx.Block.Stats.Fee = decodeCtx.Block.Stats.Fee.Add(tx.Fee)
+			if feeCollector != nil {
+				feeCollector.AddSpendableBalance(currencyBase, tx.Fee)
 			}
 		}
 
 		if t, ok := txDecoded.(signing.Tx); ok {
 			signers, err := t.GetSigners()
 			if payer := t.FeePayer(); len(payer) > 0 {
-				addr, err := addEmptyAddress(payer, currencyBase, block.Height, &data)
+				addr, err := addEmptyAddress(decodeCtx, payer, currencyBase)
 				if err != nil {
-					return data, errors.Wrap(err, "add signer")
+					return decodeCtx, errors.Wrap(err, "add signer")
 				}
 				addr.AddSpendableBalance(currencyBase, tx.Fee.Neg())
 			}
@@ -149,90 +129,75 @@ func (module *Module) parse(genesis types.GenesisOutput) (parsedData, error) {
 			if err != nil {
 				pubKeys, err := t.GetPubKeys()
 				if err != nil {
-					return data, errors.Wrap(err, "get pub keys")
+					return decodeCtx, errors.Wrap(err, "get pub keys")
 				}
-				for _, pk := range pubKeys {
-					if _, err := addEmptyAddress(pk.Address().Bytes(), currencyBase, block.Height, &data); err != nil {
-						return data, errors.Wrap(err, "add signer")
+				for i := range pubKeys {
+					signerAddress, err := addEmptyAddress(decodeCtx, pubKeys[i].Address().Bytes(), currencyBase)
+					if err != nil {
+						return decodeCtx, errors.Wrap(err, "add signer")
 					}
+					tx.Signers = append(tx.Signers, *signerAddress)
 				}
 			} else {
 				for i := range signers {
-					if _, err := addEmptyAddress(signers[i], currencyBase, block.Height, &data); err != nil {
-						return data, errors.Wrap(err, "add signer")
+					signerAddress, err := addEmptyAddress(decodeCtx, signers[i], currencyBase)
+					if err != nil {
+						return decodeCtx, errors.Wrap(err, "add signer")
 					}
+					tx.Signers = append(tx.Signers, *signerAddress)
 				}
 			}
 		}
-
 	}
 
-	for _, addr := range decodeCtx.Addresses.Values() {
-		if a, ok := data.addresses[addr.String()]; ok {
-			for i := range addr.Balances {
-				for j := range a.Balances {
-					if a.Balances[j].Currency == addr.Balances[i].Currency {
-						a.Balances[j].Spendable = a.Balances[j].Spendable.Add(addr.Balances[i].Spendable)
-						a.Balances[j].Delegated = a.Balances[j].Delegated.Add(addr.Balances[i].Delegated)
-						a.Balances[j].Unbonding = a.Balances[j].Unbonding.Add(addr.Balances[i].Unbonding)
-						break
-					}
-				}
-			}
-		} else {
-			data.addresses[addr.String()] = addr
-		}
+	if err := module.parseConstants(decodeCtx, genesis.AppState, genesis.ConsensusParams); err != nil {
+		return decodeCtx, errors.Wrap(err, "parse constants")
 	}
 
-	if err := module.parseConstants(genesis.AppState, genesis.ConsensusParams, &data); err != nil {
-		return data, errors.Wrap(err, "parse constants")
-	}
-
-	module.parseTotalSupply(genesis.AppState.Bank.Supply, &block)
-
-	data.validators = decodeCtx.Validators.Values()
-	data.stakingLogs = decodeCtx.StakingLogs
+	module.parseTotalSupply(genesis.AppState.Bank.Supply, decodeCtx.Block)
 
 	for _, delegation := range decodeCtx.Delegations.All() {
-		data.delegations = append(data.delegations, *delegation)
-		if data.bondedTokensPool != nil && len(data.bondedTokensPool.Balances) > 0 {
-			data.bondedTokensPool.Balances[0].Spendable = data.bondedTokensPool.Balances[0].Spendable.Add(delegation.Amount)
+		if bondedTokensPool != nil && len(bondedTokensPool.Balances) > 0 {
+			bondedTokensPool.Balances[0].Spendable = bondedTokensPool.Balances[0].Spendable.Add(delegation.Amount)
 		}
-		if addr, ok := data.addresses[delegation.Address.Address]; ok && len(addr.Balances) > 0 {
+		if addr, ok := decodeCtx.Addresses.Get(delegation.Address.Address); ok && len(addr.Balances) > 0 {
 			addr.Balances[0].Spendable = addr.Balances[0].Spendable.Sub(delegation.Amount)
 		}
 	}
 
-	if err := module.parseFeeGrants(genesis.AppState.Feegrant.FeeGrants, block, &data); err != nil {
-		return data, errors.Wrap(err, "parse genesis fee grants")
+	if err := module.parseFeeGrants(decodeCtx, genesis.AppState.Feegrant.FeeGrants); err != nil {
+		return decodeCtx, errors.Wrap(err, "parse genesis fee grants")
+	}
+	if err := module.parseAuthzGrants(decodeCtx, genesis.AppState.Authz.Authorization); err != nil {
+		return decodeCtx, errors.Wrap(err, "parse genesis authz grants")
 	}
 
-	if err := module.parseAccounts(genesis.AppState.Auth.Accounts, block, &data); err != nil {
-		return data, errors.Wrap(err, "parse genesis accounts")
+	if err := module.parseAccounts(decodeCtx, currencyBase, genesis.AppState.Auth.Accounts); err != nil {
+		return decodeCtx, errors.Wrap(err, "parse genesis accounts")
 	}
-	if err := module.parseBalances(genesis.AppState.Bank.Balances, block.Height, &data); err != nil {
-		return data, errors.Wrap(err, "parse genesis account balances")
+	if err := module.parseBalances(decodeCtx, genesis.AppState.Bank.Balances); err != nil {
+		return decodeCtx, errors.Wrap(err, "parse genesis account balances")
 	}
 
-	data.block = block
-	return data, nil
+	return decodeCtx, nil
 }
 
-func addEmptyAddress(pk []byte, denom string, height pkgTypes.Level, data *parsedData) (*storage.Address, error) {
+func addEmptyAddress(ctx *context.Context, pk []byte, denom string) (*storage.Address, error) {
 	address, err := pkgTypes.NewAddressFromBytes(pk)
 	if err != nil {
 		return nil, errors.Wrap(err, "NewAddressFromBytes")
 	}
 
 	readableAddress := address.String()
-	if addr, ok := data.addresses[readableAddress]; ok {
+	if addr, ok := ctx.Addresses.Get(readableAddress); ok {
 		return addr, nil
 	}
-	data.addresses[readableAddress] = &storage.Address{
+
+	addr := &storage.Address{
 		Address:    readableAddress,
 		Hash:       pk,
-		Height:     height,
-		LastHeight: height,
+		Height:     ctx.Block.Height,
+		LastHeight: ctx.Block.Height,
 		Balances: []storage.Balance{
 			{
 				Spendable: storageTypes.NumericZero(),
@@ -242,7 +207,8 @@ func addEmptyAddress(pk []byte, denom string, height pkgTypes.Level, data *parse
 			},
 		},
 	}
-	return data.addresses[readableAddress], nil
+	err = ctx.AddAddress(addr)
+	return addr, err
 }
 
 func (module *Module) parseTotalSupply(supply []types.Supply, block *storage.Block) {
@@ -263,19 +229,17 @@ func getBaseCurrency(denomMetadata []storage.DenomMetadata) string {
 	return currencyBase
 }
 
-func (module *Module) parseAccounts(accounts []types.Account, block storage.Block, data *parsedData) error {
-	currencyBase := getBaseCurrency(data.denomMetadata)
-
+func (module *Module) parseAccounts(ctx *context.Context, denom string, accounts []types.Account) error {
 	for i := range accounts {
 		address := storage.Address{
-			Height:     block.Height,
-			LastHeight: block.Height,
+			Height:     ctx.Block.Height,
+			LastHeight: ctx.Block.Height,
 			Balances: []storage.Balance{
 				{
 					Spendable: storageTypes.NumericZero(),
 					Delegated: storageTypes.NumericZero(),
 					Unbonding: storageTypes.NumericZero(),
-					Currency:  currencyBase,
+					Currency:  denom,
 				},
 			},
 		}
@@ -285,7 +249,7 @@ func (module *Module) parseAccounts(accounts []types.Account, block storage.Bloc
 		switch {
 		case strings.Contains(accounts[i].Type, "PeriodicVestingAccount"):
 			readableAddress = accounts[i].BaseVestingAccount.BaseAccount.Address
-			if err := parseVesting(accounts[i], block, readableAddress, storageTypes.VestingTypePeriodic, data); err != nil {
+			if err := parseVesting(ctx, accounts[i], readableAddress, storageTypes.VestingTypePeriodic); err != nil {
 				return err
 			}
 
@@ -293,31 +257,24 @@ func (module *Module) parseAccounts(accounts []types.Account, block storage.Bloc
 			readableAddress = accounts[i].BaseAccount.Address
 			address.Name = accounts[i].Name
 
-			switch address.Name {
-			case "bonded_tokens_pool":
-				data.bondedTokensPool = &address
-			case "fee_collector":
-				data.feeCollector = &address
-			}
-
 		case strings.Contains(accounts[i].Type, "BaseAccount"):
 			readableAddress = accounts[i].Address
 
 		case strings.Contains(accounts[i].Type, "ContinuousVestingAccount"):
 			readableAddress = accounts[i].BaseVestingAccount.BaseAccount.Address
-			if err := parseVesting(accounts[i], block, readableAddress, storageTypes.VestingTypeContinuous, data); err != nil {
+			if err := parseVesting(ctx, accounts[i], readableAddress, storageTypes.VestingTypeContinuous); err != nil {
 				return err
 			}
 
 		case strings.Contains(accounts[i].Type, "DelayedVestingAccount"):
 			readableAddress = accounts[i].BaseVestingAccount.BaseAccount.Address
-			if err := parseVesting(accounts[i], block, readableAddress, storageTypes.VestingTypeDelayed, data); err != nil {
+			if err := parseVesting(ctx, accounts[i], readableAddress, storageTypes.VestingTypeDelayed); err != nil {
 				return err
 			}
 
 		case strings.Contains(accounts[i].Type, "PermanentLockedAccount"):
 			readableAddress = accounts[i].BaseVestingAccount.BaseAccount.Address
-			if err := parseVesting(accounts[i], block, readableAddress, storageTypes.VestingTypePermanent, data); err != nil {
+			if err := parseVesting(ctx, accounts[i], readableAddress, storageTypes.VestingTypePermanent); err != nil {
 				return err
 			}
 
@@ -325,67 +282,28 @@ func (module *Module) parseAccounts(accounts []types.Account, block storage.Bloc
 			return errors.Errorf("unknown account type: %s", accounts[i].Type)
 		}
 
-		if _, ok := data.addresses[readableAddress]; !ok {
-			_, hash, err := pkgTypes.Address(readableAddress).Decode()
-			if err != nil {
-				return err
-			}
-			address.Hash = hash
-			address.Address = readableAddress
-			data.addresses[address.String()] = &address
+		address.Address = readableAddress
+		if err := ctx.AddAddress(&address); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-func addAddress(data *parsedData, block storage.Block, address string) error {
-	if _, ok := data.addresses[address]; ok {
-		return nil
-	}
-	currencyBase := getBaseCurrency(data.denomMetadata)
-
-	addr := &storage.Address{
-		Address:    address,
-		Height:     block.Height,
-		LastHeight: block.Height,
-		Balances: []storage.Balance{
-			{
-				Spendable: storageTypes.NumericZero(),
-				Delegated: storageTypes.NumericZero(),
-				Unbonding: storageTypes.NumericZero(),
-				Currency:  currencyBase,
-			},
-		},
-	}
-	_, hash, err := pkgTypes.Address(address).Decode()
-	if err != nil {
-		return err
-	}
-	addr.Hash = hash
-	data.addresses[address] = addr
-	return nil
-}
-
-func (module *Module) parseBalances(balances []types.Balances, height pkgTypes.Level, data *parsedData) error {
+func (module *Module) parseBalances(ctx *context.Context, balances []types.Balances) error {
 	for i := range balances {
 		if len(balances[i].Coins) == 0 {
 			continue
 		}
 
-		addr, ok := data.addresses[balances[i].Address]
+		addr, ok := ctx.Addresses.Get(balances[i].Address)
 		if !ok {
-			_, hash, err := pkgTypes.Address(balances[i].Address).Decode()
-			if err != nil {
-				return err
-			}
 			addr = &storage.Address{
-				Hash:       hash,
 				Address:    balances[i].Address,
-				Height:     height,
-				LastHeight: height,
+				Height:     ctx.Block.Height,
+				LastHeight: ctx.Block.Height,
 				Balances:   make([]storage.Balance, 0, len(balances[i].Coins)),
 			}
-			data.addresses[addr.String()] = addr
 		}
 
 		for _, coin := range balances[i].Coins {
@@ -394,6 +312,12 @@ func (module *Module) parseBalances(balances []types.Balances, height pkgTypes.L
 				continue
 			}
 			addr.AddSpendableBalance(coin.Denom, value)
+		}
+
+		if !ok {
+			if err := ctx.AddAddress(addr); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -414,15 +338,15 @@ func getAmountFromOriginalVesting(vestings []types.Coins) (storageTypes.Numeric,
 	return amount, nil
 }
 
-func parseVesting(acc types.Account, block storage.Block, address string, typ storageTypes.VestingType, data *parsedData) error {
+func parseVesting(ctx *context.Context, acc types.Account, address string, typ storageTypes.VestingType) error {
 	amount, err := getAmountFromOriginalVesting(acc.BaseVestingAccount.OriginalVesting)
 	if err != nil {
 		return err
 	}
 
 	v := storage.VestingAccount{
-		Height: block.Height,
-		Time:   block.Time,
+		Height: ctx.Block.Height,
+		Time:   ctx.Block.Time,
 		Address: &storage.Address{
 			Address: address,
 		},
@@ -456,7 +380,6 @@ func parseVesting(acc types.Account, block storage.Block, address string, typ st
 		period.Time = periodTime
 		v.VestingPeriods = append(v.VestingPeriods, period)
 	}
-
-	data.vestings = append(data.vestings, &v)
+	ctx.AddVestingAccount(&v)
 	return nil
 }

--- a/pkg/indexer/genesis/save.go
+++ b/pkg/indexer/genesis/save.go
@@ -9,83 +9,79 @@ import (
 
 	"github.com/celenium-io/celestia-indexer/internal/storage"
 	"github.com/celenium-io/celestia-indexer/internal/storage/postgres"
+	decodeContext "github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
+	"github.com/pkg/errors"
 )
 
-func (module *Module) save(ctx context.Context, data parsedData) error {
+var errCantFindAddressInContext = errors.New("can't find address in context")
+
+func (module *Module) save(ctx context.Context, decodeCtx *decodeContext.Context) error {
 	start := time.Now()
-	module.Log.Info().Uint64("height", uint64(data.block.Height)).Msg("saving block...")
+	module.Log.Info().Uint64("height", uint64(decodeCtx.Block.Height)).Msg("saving block...")
 	tx, err := postgres.BeginTransaction(ctx, module.storage.Transactable)
 	if err != nil {
 		return err
 	}
 	defer tx.Close(ctx)
 
-	if err := tx.SaveConstants(ctx, data.constants...); err != nil {
+	newConstants := make([]storage.Constant, 0, decodeCtx.Constants.Len())
+	for constant := range decodeCtx.Constants.AllValues() {
+		newConstants = append(newConstants, *constant)
+	}
+	if err := tx.SaveConstants(ctx, newConstants...); err != nil {
 		return tx.HandleError(ctx, err)
 	}
 
-	for i := range data.denomMetadata {
-		if err := tx.Add(ctx, &data.denomMetadata[i]); err != nil {
+	for i := range decodeCtx.DenomMetadata {
+		if err := tx.Add(ctx, &decodeCtx.DenomMetadata[i]); err != nil {
 			return tx.HandleError(ctx, err)
 		}
 	}
 
-	if err := tx.Add(ctx, &data.block); err != nil {
+	if err := tx.Add(ctx, decodeCtx.Block); err != nil {
 		return tx.HandleError(ctx, err)
 	}
 
-	if err := tx.Add(ctx, &data.block.Stats); err != nil {
+	if err := tx.Add(ctx, &decodeCtx.Block.Stats); err != nil {
 		return tx.HandleError(ctx, err)
 	}
 
-	if err := tx.SaveTransactions(ctx, data.block.Txs...); err != nil {
+	if err := tx.SaveTransactions(ctx, decodeCtx.Block.Txs...); err != nil {
 		return tx.HandleError(ctx, err)
 	}
 
 	var (
 		messages   = make([]*storage.Message, 0, 1000)
-		events     = make([]any, len(data.block.Events))
+		events     = make([]any, len(decodeCtx.Block.Events))
 		namespaces = make(map[string]*storage.Namespace, 0)
 	)
 
-	for i := range data.block.Events {
-		events[i] = &data.block.Events[i]
+	for i := range decodeCtx.Block.Events {
+		events[i] = &decodeCtx.Block.Events[i]
 	}
 
-	for i := range data.block.Txs {
-		for j := range data.block.Txs[i].Messages {
-			messages = append(messages, &data.block.Txs[i].Messages[j])
+	for i := range decodeCtx.Block.Txs {
+		for j := range decodeCtx.Block.Txs[i].Messages {
+			messages = append(messages, &decodeCtx.Block.Txs[i].Messages[j])
 
-			for k := range data.block.Txs[i].Messages[j].Namespace {
-				key := data.block.Txs[i].Messages[j].Namespace[k].String()
+			for k := range decodeCtx.Block.Txs[i].Messages[j].Namespace {
+				key := decodeCtx.Block.Txs[i].Messages[j].Namespace[k].String()
 				if _, ok := namespaces[key]; !ok {
-					data.block.Txs[i].Messages[j].Namespace[k].PfbCount = 1
-					namespaces[key] = &data.block.Txs[i].Messages[j].Namespace[k]
+					decodeCtx.Block.Txs[i].Messages[j].Namespace[k].PfbCount = 1
+					namespaces[key] = &decodeCtx.Block.Txs[i].Messages[j].Namespace[k]
 				}
 			}
 		}
 
-		for j := range data.block.Txs[i].Events {
-			data.block.Txs[i].Events[j].TxId = &data.block.Txs[i].Id
-			events = append(events, &data.block.Txs[i].Events[j])
-		}
-
-		for j := range data.block.Txs[i].Signers {
-			key := data.block.Txs[i].Signers[j].String()
-			if addr, ok := data.addresses[key]; !ok {
-				data.addresses[key] = &data.block.Txs[i].Signers[j]
-			} else if len(addr.Balances) > 0 && len(data.block.Txs[i].Signers[j].Balances) > 0 {
-				addr.Balances[0].Spendable = addr.Balances[0].Spendable.Add(data.block.Txs[i].Signers[j].Balances[0].Spendable)
-			}
+		for j := range decodeCtx.Block.Txs[i].Events {
+			decodeCtx.Block.Txs[i].Events[j].TxId = &decodeCtx.Block.Txs[i].Id
+			events = append(events, &decodeCtx.Block.Txs[i].Events[j])
 		}
 	}
 
 	var totalAccounts int64
-	if len(data.addresses) > 0 {
-		entities := make([]*storage.Address, 0, len(data.addresses))
-		for key := range data.addresses {
-			entities = append(entities, data.addresses[key])
-		}
+	if decodeCtx.Addresses.Len() > 0 {
+		entities := decodeCtx.Addresses.Values()
 
 		totalAccounts, err = tx.SaveAddresses(ctx, entities...)
 		if err != nil {
@@ -117,7 +113,8 @@ func (module *Module) save(ctx context.Context, data parsedData) error {
 		}
 	}
 
-	totalValidators, err := tx.SaveValidators(ctx, data.validators...)
+	validators := decodeCtx.Validators.Values()
+	totalValidators, err := tx.SaveValidators(ctx, validators...)
 	if err != nil {
 		return tx.HandleError(ctx, err)
 	}
@@ -129,13 +126,13 @@ func (module *Module) save(ctx context.Context, data parsedData) error {
 	var msgVals []storage.MsgValidator
 	for i := range messages {
 		for _, val := range messages[i].Validators {
-			for j := range data.validators {
-				if data.validators[j].Address == val {
+			for j := range validators {
+				if validators[j].Address == val {
 					msgVals = append(msgVals, storage.MsgValidator{
 						Height:      0,
-						Time:        data.block.Time,
+						Time:        decodeCtx.Block.Time,
 						MsgId:       messages[i].Id,
-						ValidatorId: data.validators[j].Id,
+						ValidatorId: validators[j].Id,
 					})
 					break
 				}
@@ -147,57 +144,66 @@ func (module *Module) save(ctx context.Context, data parsedData) error {
 		return tx.HandleError(ctx, err)
 	}
 
-	for i := range data.stakingLogs {
-		if address, ok := data.addresses[data.stakingLogs[i].Address.Address]; ok {
-			data.stakingLogs[i].AddressId = &address.Id
+	for i := range decodeCtx.StakingLogs {
+		if address, ok := decodeCtx.Addresses.Get(decodeCtx.StakingLogs[i].Address.Address); ok {
+			decodeCtx.StakingLogs[i].AddressId = &address.Id
+		} else {
+			return tx.HandleError(ctx, errors.Wrap(errCantFindAddressInContext, decodeCtx.StakingLogs[i].Address.Address))
 		}
 
-		for j := range data.validators {
-			if data.validators[j].Address == data.stakingLogs[i].Validator.Address {
-				data.stakingLogs[i].ValidatorId = data.validators[j].Id
+		for j := range validators {
+			if validators[j].Address == decodeCtx.StakingLogs[i].Validator.Address {
+				decodeCtx.StakingLogs[i].ValidatorId = validators[j].Id
 				break
 			}
 		}
 	}
 
-	if err := tx.SaveStakingLogs(ctx, data.stakingLogs...); err != nil {
+	if err := tx.SaveStakingLogs(ctx, decodeCtx.StakingLogs...); err != nil {
 		return tx.HandleError(ctx, err)
 	}
 
-	for i := range data.vestings {
-		if address, ok := data.addresses[data.vestings[i].Address.Address]; ok {
-			data.vestings[i].AddressId = address.Id
+	for i := range decodeCtx.VestingAccounts {
+		if address, ok := decodeCtx.Addresses.Get(decodeCtx.VestingAccounts[i].Address.Address); ok {
+			decodeCtx.VestingAccounts[i].AddressId = address.Id
+		} else {
+			return tx.HandleError(ctx, errors.Wrap(errCantFindAddressInContext, decodeCtx.VestingAccounts[i].Address.Address))
 		}
 	}
 
-	if err := tx.SaveVestingAccounts(ctx, data.vestings...); err != nil {
+	if err := tx.SaveVestingAccounts(ctx, decodeCtx.VestingAccounts...); err != nil {
 		return tx.HandleError(ctx, err)
 	}
 
 	periods := make([]storage.VestingPeriod, 0)
-	for i := range data.vestings {
-		for j := range data.vestings[i].VestingPeriods {
-			data.vestings[i].VestingPeriods[j].VestingAccountId = data.vestings[i].Id
+	for i := range decodeCtx.VestingAccounts {
+		for j := range decodeCtx.VestingAccounts[i].VestingPeriods {
+			decodeCtx.VestingAccounts[i].VestingPeriods[j].VestingAccountId = decodeCtx.VestingAccounts[i].Id
 		}
-		periods = append(periods, data.vestings[i].VestingPeriods...)
+		periods = append(periods, decodeCtx.VestingAccounts[i].VestingPeriods...)
 	}
 	if err := tx.SaveVestingPeriods(ctx, periods...); err != nil {
 		return tx.HandleError(ctx, err)
 	}
 
-	for i := range data.delegations {
-		if address, ok := data.addresses[data.delegations[i].Address.Address]; ok {
-			data.delegations[i].AddressId = address.Id
+	delegations := make([]storage.Delegation, 0, decodeCtx.Delegations.Len())
+	for delegation := range decodeCtx.Delegations.AllValues() {
+		if address, ok := decodeCtx.Addresses.Get(delegation.Address.Address); ok {
+			delegation.AddressId = address.Id
+		} else {
+			return tx.HandleError(ctx, errors.Wrap(errCantFindAddressInContext, delegation.Address.Address))
 		}
 
-		for j := range data.validators {
-			if data.validators[j].Address == data.delegations[i].Validator.Address {
-				data.delegations[i].ValidatorId = data.validators[j].Id
+		for j := range validators {
+			if validators[j].Address == delegation.Validator.Address {
+				delegation.ValidatorId = validators[j].Id
 				break
 			}
 		}
+
+		delegations = append(delegations, *delegation)
 	}
-	if err := tx.SaveDelegations(ctx, data.delegations...); err != nil {
+	if err := tx.SaveDelegations(ctx, delegations...); err != nil {
 		return tx.HandleError(ctx, err)
 	}
 
@@ -228,11 +234,15 @@ func (module *Module) save(ctx context.Context, data parsedData) error {
 	}
 
 	var signers []storage.Signer
-	for i := range data.block.Txs {
-		for _, address := range data.block.Txs[i].Signers {
+	for i := range decodeCtx.Block.Txs {
+		for _, address := range decodeCtx.Block.Txs[i].Signers {
+			signer, ok := decodeCtx.Addresses.Get(address.Address)
+			if !ok {
+				return tx.HandleError(ctx, errors.Wrap(errCantFindAddressInContext, address.Address))
+			}
 			signers = append(signers, storage.Signer{
-				TxId:      data.block.Txs[i].Id,
-				AddressId: address.Id,
+				TxId:      decodeCtx.Block.Txs[i].Id,
+				AddressId: signer.Id,
 			})
 		}
 	}
@@ -243,14 +253,14 @@ func (module *Module) save(ctx context.Context, data parsedData) error {
 
 	if err := tx.Add(ctx, &storage.State{
 		Name:            module.indexerName,
-		LastHeight:      data.block.Height,
-		LastTime:        data.block.Time,
-		LastHash:        data.block.Hash,
-		ChainId:         data.block.ChainId,
-		TotalTx:         data.block.Stats.TxCount,
-		TotalSupply:     data.block.Stats.SupplyChange,
-		TotalFee:        data.block.Stats.Fee,
-		TotalBlobsSize:  data.block.Stats.BlobsSize,
+		LastHeight:      decodeCtx.Block.Height,
+		LastTime:        decodeCtx.Block.Time,
+		LastHash:        decodeCtx.Block.Hash,
+		ChainId:         decodeCtx.Block.ChainId,
+		TotalTx:         decodeCtx.Block.Stats.TxCount,
+		TotalSupply:     decodeCtx.Block.Stats.SupplyChange,
+		TotalFee:        decodeCtx.Block.Stats.Fee,
+		TotalBlobsSize:  decodeCtx.Block.Stats.BlobsSize,
 		TotalAccounts:   totalAccounts,
 		TotalNamespaces: totalNamespaces,
 		TotalValidators: totalValidators,
@@ -258,16 +268,22 @@ func (module *Module) save(ctx context.Context, data parsedData) error {
 		return tx.HandleError(ctx, err)
 	}
 
-	for i := range data.grants {
-		if address, ok := data.addresses[data.grants[i].Grantee.Address]; ok {
-			data.grants[i].GranteeId = address.Id
+	grants := make([]*storage.Grant, 0, decodeCtx.Grants.Len())
+	for grant := range decodeCtx.Grants.AllValues() {
+		if address, ok := decodeCtx.Addresses.Get(grant.Grantee.Address); ok {
+			grant.GranteeId = address.Id
+		} else {
+			return tx.HandleError(ctx, errors.Wrap(errCantFindAddressInContext, grant.Grantee.Address))
 		}
-		if address, ok := data.addresses[data.grants[i].Granter.Address]; ok {
-			data.grants[i].GranterId = address.Id
+		if address, ok := decodeCtx.Addresses.Get(grant.Granter.Address); ok {
+			grant.GranterId = address.Id
+		} else {
+			return tx.HandleError(ctx, errors.Wrap(errCantFindAddressInContext, grant.Granter.Address))
 		}
+		grants = append(grants, grant)
 	}
 
-	if err := tx.SaveGrants(ctx, data.grants...); err != nil {
+	if err := tx.SaveGrants(ctx, grants...); err != nil {
 		return tx.HandleError(ctx, err)
 	}
 
@@ -275,9 +291,9 @@ func (module *Module) save(ctx context.Context, data parsedData) error {
 		return tx.HandleError(ctx, err)
 	}
 	module.Log.Info().
-		Uint64("height", data.block.Id).
-		Int64("block_ns_size", data.block.Stats.BlobsSize).
-		Str("block_fee", data.block.Stats.Fee.String()).
+		Uint64("height", decodeCtx.Block.Id).
+		Int64("block_ns_size", decodeCtx.Block.Stats.BlobsSize).
+		Str("block_fee", decodeCtx.Block.Stats.Fee.String()).
 		Int64("ms", time.Since(start).Milliseconds()).
 		Msg("block saved")
 	return nil

--- a/pkg/indexer/genesis/save.go
+++ b/pkg/indexer/genesis/save.go
@@ -164,6 +164,9 @@ func (module *Module) save(ctx context.Context, decodeCtx *decodeContext.Context
 	}
 
 	for i := range decodeCtx.VestingAccounts {
+		if decodeCtx.VestingAccounts[i] == nil || decodeCtx.VestingAccounts[i].Address == nil {
+			return tx.HandleError(ctx, errors.New("nil pointer for vesting"))
+		}
 		if address, ok := decodeCtx.Addresses.Get(decodeCtx.VestingAccounts[i].Address.Address); ok {
 			decodeCtx.VestingAccounts[i].AddressId = address.Id
 		} else {

--- a/pkg/indexer/genesis/save_test.go
+++ b/pkg/indexer/genesis/save_test.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2025 Bb Strategy Pte. Ltd. <celenium@baking-bad.org>
+// SPDX-License-Identifier: MIT
+
+package genesis
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	json "github.com/bytedance/sonic"
+	"github.com/celenium-io/celestia-indexer/internal/storage/postgres"
+	"github.com/celenium-io/celestia-indexer/pkg/indexer/config"
+	decodeContext "github.com/celenium-io/celestia-indexer/pkg/indexer/decode/context"
+	"github.com/celenium-io/celestia-indexer/pkg/node/types"
+	dipdupConfig "github.com/dipdup-io/go-lib/config"
+	"github.com/dipdup-io/go-lib/testhelpers"
+	"github.com/stretchr/testify/suite"
+)
+
+// SaveTestSuite spins up a real TimescaleDB container, since Module.save opens a
+// genuine DB transaction (postgres.BeginTransaction) and can't be exercised against
+// a zero-value postgres.Storage.
+type SaveTestSuite struct {
+	suite.Suite
+	psqlContainer *testhelpers.PostgreSQLContainer
+	storage       postgres.Storage
+}
+
+func (s *SaveTestSuite) SetupSuite() {
+	ctx, ctxCancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer ctxCancel()
+
+	psqlContainer, err := testhelpers.NewPostgreSQLContainer(ctx, testhelpers.PostgreSQLContainerConfig{
+		User:     "user",
+		Password: "password",
+		Database: "db_test",
+		Port:     5432,
+		Image:    "timescale/timescaledb-ha:pg15.8-ts2.17.0-all",
+	})
+	s.Require().NoError(err)
+	s.psqlContainer = psqlContainer
+	s.T().Cleanup(func() {
+		ctx, ctxCancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer ctxCancel()
+		s.Require().NoError(s.psqlContainer.Terminate(ctx))
+	})
+
+	strg, err := postgres.Create(ctx, dipdupConfig.Database{
+		Kind:     dipdupConfig.DBKindPostgres,
+		User:     s.psqlContainer.Config.User,
+		Database: s.psqlContainer.Config.Database,
+		Password: s.psqlContainer.Config.Password,
+		Host:     s.psqlContainer.Config.Host,
+		Port:     s.psqlContainer.MappedPort().Int(),
+	}, "../../../database", false)
+	s.Require().NoError(err)
+	s.storage = strg
+	s.T().Cleanup(func() {
+		s.Require().NoError(s.storage.Close())
+	})
+}
+
+// parsedGenesisContext builds a decode context by running the real parser over the
+// genesis.json fixture, so it is a known-good, DB-writable context before any test
+// deliberately corrupts a part of it.
+func (s *SaveTestSuite) parsedGenesisContext(module Module) *decodeContext.Context {
+	f, err := os.Open("../../../test/json/genesis.json")
+	s.Require().NoError(err)
+	defer f.Close()
+
+	var g types.Genesis
+	s.Require().NoError(json.ConfigFastest.NewDecoder(f).Decode(&g))
+
+	dCtx, err := module.parse(types.GenesisOutput{Genesis: g})
+	s.Require().NoError(err)
+	return dCtx
+}
+
+// Regression guard: a nil entry (or one with a nil Address) in decodeCtx.VestingAccounts
+// used to reach decodeCtx.VestingAccounts[i].Address.Address directly and panic with a
+// nil pointer dereference instead of failing the block gracefully.
+func (s *SaveTestSuite) TestSave_NilVestingAccountReturnsErrorInsteadOfPanicking() {
+	module := NewModule(s.storage, config.Indexer{Name: "test_indexer"})
+	dCtx := s.parsedGenesisContext(module)
+
+	dCtx.VestingAccounts = append(dCtx.VestingAccounts, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	s.Require().NotPanics(func() {
+		err := module.save(ctx, dCtx)
+		s.Require().Error(err)
+	})
+}
+
+func TestSuiteSave_Run(t *testing.T) {
+	suite.Run(t, new(SaveTestSuite))
+}

--- a/pkg/node/types/genesis.go
+++ b/pkg/node/types/genesis.go
@@ -467,3 +467,10 @@ type MinFee struct {
 		NetworkMinGasPrice string `json:"network_min_gas_price"`
 	} `json:"params"`
 }
+
+func (fee MinFee) GetNetworkMinGasPrice() string {
+	if fee.Params.NetworkMinGasPrice != "" {
+		return fee.Params.NetworkMinGasPrice
+	}
+	return fee.NetworkMinGasPrice
+}

--- a/pkg/node/types/genesis.go
+++ b/pkg/node/types/genesis.go
@@ -75,7 +75,7 @@ type Auth struct {
 }
 
 type Authz struct {
-	Authorization []interface{} `json:"authorization"`
+	Authorization []json.RawMessage `json:"authorization"`
 }
 
 type BankParams struct {
@@ -452,10 +452,18 @@ type AppState struct {
 	Gov          Gov          `json:"gov"`
 	Ibc          Ibc          `json:"ibc"`
 	Mint         Mint         `json:"mint"`
+	MinFee       MinFee       `json:"minfee"`
 	Params       interface{}  `json:"params"`
 	Qgb          Qgb          `json:"qgb"`
 	Slashing     Slashing     `json:"slashing"`
 	Staking      Staking      `json:"staking"`
 	Transfer     Transfer     `json:"transfer"`
 	Vesting      Vesting      `json:"vesting"`
+}
+
+type MinFee struct {
+	NetworkMinGasPrice string `json:"network_min_gas_price"`
+	Params             struct {
+		NetworkMinGasPrice string `json:"network_min_gas_price"`
+	} `json:"params"`
 }

--- a/pkg/node/types/genesis_test.go
+++ b/pkg/node/types/genesis_test.go
@@ -125,3 +125,24 @@ func TestGov_GetTallyParams(t *testing.T) {
 		require.Zero(t, got)
 	})
 }
+
+func TestMinFee_GetNetworkMinGasPrice(t *testing.T) {
+	t.Run("new params format takes priority", func(t *testing.T) {
+		fee := MinFee{
+			NetworkMinGasPrice: "0.000001",
+		}
+		fee.Params.NetworkMinGasPrice = "0.00002"
+		require.Equal(t, "0.00002", fee.GetNetworkMinGasPrice())
+	})
+
+	t.Run("legacy format", func(t *testing.T) {
+		fee := MinFee{
+			NetworkMinGasPrice: "0.000001",
+		}
+		require.Equal(t, "0.000001", fee.GetNetworkMinGasPrice())
+	})
+
+	t.Run("no value", func(t *testing.T) {
+		require.Equal(t, "", MinFee{}.GetNetworkMinGasPrice())
+	})
+}


### PR DESCRIPTION
## Summary

- Parse `authz` grants from the genesis block (`AppState.Authz.Authorization`), alongside the existing `feegrant` parsing, reusing the same `handle.MsgGrant`/`handle.MsgGrantAllowance` decoders the per-block pipeline already uses.
- Refactor genesis parsing to use `*decode/context.Context` as the single accumulator instead of a parallel `parsedData` struct, removing the manual address-merge step and duplicate address bookkeeping between the two.
- `authz.MsgGrant` authorization types outside the known switch (`GenericAuthorization`/`SendAuthorization`/`StakeAuthorization`) now produce a generic grant record (raw `type_url`, no decoded `Params`) instead of being silently dropped, in both genesis and normal block parsing.
- Add `StakeAuthorization`'s `CANCEL_UNBONDING_DELEGATION` case (previously unhandled).
- Parse the `minfee` module's `network_min_gas_price` genesis constant (new `ModuleNameMinfee`).

## Fixes found during review

- `parseBalances` was re-running an address it had just mutated in place back through `ctx.AddAddress`, doubling every balance for any account that already existed in the address map (i.e. almost every genesis account).
- `bondedTokensPool`/`feeCollector` module-account pointers were captured before the account was actually inserted into the address map, so fee/delegation credits applied during genesis silently landed on a discarded object instead of the saved address.

## Test plan

- [x] `pkg/indexer/genesis`: rewritten `parse.go`/`grants.go` tests against the new `*context.Context`-based signatures; added `constant_test.go` (previously zero coverage for `parseConstants`, including the new `minfee` block); extended `TestParseAuthzGrants_StakeAuthorization` with the new cancel-unbonding case.
- [x] `pkg/indexer/decode/handle/test`: added coverage for the generic/unrecognized authorization fallback in `parseGrants`.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- [x] `go test ./pkg/indexer/...` green (except the two Docker-backed testcontainers suites, which need Docker running locally).