### PR TITLE
Parse ICA host `allow_messages` from genesis

### DIFF
--- a/pkg/indexer/genesis/constant.go
+++ b/pkg/indexer/genesis/constant.go
@@ -251,5 +251,14 @@ func (module *Module) parseConstants(ctx *decodeContext.Context, appState types.
 		appState.MinFee.GetNetworkMinGasPrice(),
 	)
 
+	// interchain accounts
+	if len(appState.InterchainAccounts.HostGenesisState.Params.AllowMessages) > 0 {
+		ctx.AddConstant(
+			storageTypes.ModuleNameIcahost,
+			"allow_messages",
+			string(appState.InterchainAccounts.HostGenesisState.Params.AllowMessages),
+		)
+	}
+
 	return nil
 }

--- a/pkg/indexer/genesis/constant_test.go
+++ b/pkg/indexer/genesis/constant_test.go
@@ -4,6 +4,7 @@
 package genesis
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"testing"
@@ -89,6 +90,18 @@ func testAppState() types.AppState {
 	}
 }
 
+// testAppStateWithIcahost returns testAppState with the interchain accounts
+// host genesis state populated, mirroring a real chain export.
+func testAppStateWithIcahost(allowMessages string) types.AppState {
+	appState := testAppState()
+	appState.InterchainAccounts.HostGenesisState.Port = "icahost"
+	appState.InterchainAccounts.HostGenesisState.Params.HostEnabled = true
+	if allowMessages != "" {
+		appState.InterchainAccounts.HostGenesisState.Params.AllowMessages = json.RawMessage(allowMessages)
+	}
+	return appState
+}
+
 func testConsensusParams() pkgTypes.ConsensusParams {
 	return pkgTypes.ConsensusParams{
 		Block: &pkgTypes.BlockParams{
@@ -118,7 +131,7 @@ func constantsMap(ctx *decodeContext.Context) map[string]string {
 func TestParseConstants(t *testing.T) {
 	module := NewModule(postgres.Storage{}, config.Indexer{})
 	ctx := decodeContext.NewContext()
-	appState := testAppState()
+	appState := testAppStateWithIcahost(`["*"]`)
 	consensus := testConsensusParams()
 
 	err := module.parseConstants(ctx, appState, consensus)
@@ -169,9 +182,52 @@ func TestParseConstants(t *testing.T) {
 		"staking.min_commission_rate": "0.05",
 
 		"minfee.network_min_gas_price": "0.000001",
+
+		"icahost.allow_messages": `["*"]`,
 	}
 
 	require.Equal(t, want, constantsMap(ctx))
+}
+
+func TestParseConstants_IcahostAllowMessages(t *testing.T) {
+	cases := []struct {
+		name          string
+		allowMessages string
+		want          string
+	}{
+		{
+			name:          "wildcard allows every message type",
+			allowMessages: `["*"]`,
+			want:          `["*"]`,
+		},
+		{
+			name:          "explicit list of allowed message types",
+			allowMessages: `["/cosmos.bank.v1beta1.MsgSend","/cosmos.staking.v1beta1.MsgDelegate"]`,
+			want:          `["/cosmos.bank.v1beta1.MsgSend","/cosmos.staking.v1beta1.MsgDelegate"]`,
+		},
+		{
+			name:          "empty list disallows every message type",
+			allowMessages: `[]`,
+			want:          `[]`,
+		},
+		{
+			name:          "field absent from genesis",
+			allowMessages: "",
+			want:          "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			module := NewModule(postgres.Storage{}, config.Indexer{})
+			ctx := decodeContext.NewContext()
+			appState := testAppStateWithIcahost(tc.allowMessages)
+
+			err := module.parseConstants(ctx, appState, testConsensusParams())
+			require.NoError(t, err)
+			require.Equal(t, tc.want, constantsMap(ctx)["icahost.allow_messages"])
+		})
+	}
 }
 
 func TestParseConstants_ZeroMinDepositOmitted(t *testing.T) {

--- a/pkg/node/types/genesis.go
+++ b/pkg/node/types/genesis.go
@@ -439,26 +439,27 @@ type Vesting struct {
 }
 
 type AppState struct {
-	Auth         Auth         `json:"auth"`
-	Authz        Authz        `json:"authz"`
-	Bank         Bank         `json:"bank"`
-	Blob         BlobState    `json:"blob"`
-	Capability   Capability   `json:"capability"`
-	Crisis       Crisis       `json:"crisis"`
-	Distribution Distribution `json:"distribution"`
-	Evidence     Evidence     `json:"evidence"`
-	Feegrant     Feegrant     `json:"feegrant"`
-	Genutil      Genutil      `json:"genutil"`
-	Gov          Gov          `json:"gov"`
-	Ibc          Ibc          `json:"ibc"`
-	Mint         Mint         `json:"mint"`
-	MinFee       MinFee       `json:"minfee"`
-	Params       interface{}  `json:"params"`
-	Qgb          Qgb          `json:"qgb"`
-	Slashing     Slashing     `json:"slashing"`
-	Staking      Staking      `json:"staking"`
-	Transfer     Transfer     `json:"transfer"`
-	Vesting      Vesting      `json:"vesting"`
+	Auth               Auth               `json:"auth"`
+	Authz              Authz              `json:"authz"`
+	Bank               Bank               `json:"bank"`
+	Blob               BlobState          `json:"blob"`
+	Capability         Capability         `json:"capability"`
+	Crisis             Crisis             `json:"crisis"`
+	Distribution       Distribution       `json:"distribution"`
+	Evidence           Evidence           `json:"evidence"`
+	Feegrant           Feegrant           `json:"feegrant"`
+	Genutil            Genutil            `json:"genutil"`
+	Gov                Gov                `json:"gov"`
+	Ibc                Ibc                `json:"ibc"`
+	InterchainAccounts InterchainAccounts `json:"interchainaccounts"`
+	Mint               Mint               `json:"mint"`
+	MinFee             MinFee             `json:"minfee"`
+	Params             interface{}        `json:"params"`
+	Qgb                Qgb                `json:"qgb"`
+	Slashing           Slashing           `json:"slashing"`
+	Staking            Staking            `json:"staking"`
+	Transfer           Transfer           `json:"transfer"`
+	Vesting            Vesting            `json:"vesting"`
 }
 
 type MinFee struct {
@@ -473,4 +474,16 @@ func (fee MinFee) GetNetworkMinGasPrice() string {
 		return fee.Params.NetworkMinGasPrice
 	}
 	return fee.NetworkMinGasPrice
+}
+
+type InterchainAccounts struct {
+	HostGenesisState struct {
+		Port   string                   `json:"port"`
+		Params InterchainAccountsParams `json:"params"`
+	} `json:"host_genesis_state"`
+}
+
+type InterchainAccountsParams struct {
+	HostEnabled   bool            `json:"host_enabled"`
+	AllowMessages json.RawMessage `json:"allow_messages"`
 }

--- a/pkg/node/types/genesis_test.go
+++ b/pkg/node/types/genesis_test.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/celenium-io/celestia-indexer/internal/currency"
@@ -144,5 +145,47 @@ func TestMinFee_GetNetworkMinGasPrice(t *testing.T) {
 
 	t.Run("no value", func(t *testing.T) {
 		require.Equal(t, "", MinFee{}.GetNetworkMinGasPrice())
+	})
+}
+
+func TestAppState_UnmarshalInterchainAccounts(t *testing.T) {
+	t.Run("host genesis state", func(t *testing.T) {
+		raw := `{
+			"interchainaccounts": {
+				"controller_genesis_state": {
+					"active_channels": [],
+					"interchain_accounts": [],
+					"ports": [],
+					"params": {}
+				},
+				"host_genesis_state": {
+					"active_channels": [],
+					"interchain_accounts": [],
+					"port": "icahost",
+					"params": {
+						"host_enabled": true,
+						"allow_messages": ["*"]
+					}
+				}
+			}
+		}`
+
+		var appState AppState
+		err := json.Unmarshal([]byte(raw), &appState)
+		require.NoError(t, err)
+
+		host := appState.InterchainAccounts.HostGenesisState
+		require.Equal(t, "icahost", host.Port)
+		require.True(t, host.Params.HostEnabled)
+		require.JSONEq(t, `["*"]`, string(host.Params.AllowMessages))
+	})
+
+	t.Run("missing interchainaccounts key", func(t *testing.T) {
+		var appState AppState
+		err := json.Unmarshal([]byte(`{}`), &appState)
+		require.NoError(t, err)
+		require.Empty(t, appState.InterchainAccounts.HostGenesisState.Port)
+		require.False(t, appState.InterchainAccounts.HostGenesisState.Params.HostEnabled)
+		require.Nil(t, appState.InterchainAccounts.HostGenesisState.Params.AllowMessages)
 	})
 }


### PR DESCRIPTION
Adds parsing of the `interchainaccounts.host_genesis_state.params.allow_messages` field from the genesis block into the `icahost` module constants, alongside the existing genesis constants (consensus, auth, blob, gov, staking, etc.).

- Add `InterchainAccounts` types to `AppState` (`pkg/node/types/genesis.go`)
- Store `allow_messages` as an `icahost` constant during genesis parsing, skipped when absent
- Add unit tests for JSON unmarshaling and constant parsing (wildcard, explicit message list, empty list, missing field)
